### PR TITLE
fix(coin-tester): viteCommonjs should skipPreBuild

### DIFF
--- a/packages/coin-tester/vite.config.ts
+++ b/packages/coin-tester/vite.config.ts
@@ -13,5 +13,5 @@ export default defineConfig({
       process: require.resolve('process/browser'),
     },
   },
-  plugins: [react(), viteCommonjs()],
+  plugins: [react(), viteCommonjs({ skipPreBuild: true })],
 });


### PR DESCRIPTION
## Summary

Package `@coolwallet/xml` use `stellar-sdk` which is using `es6-promise`.
`es6-promise` inline require `vertx` package. 
If `vite-common-js` will transform all inline require to global require , it will cause some issues.

## Reference

https://github.com/originjs/vite-plugins/issues/17