### PR TITLE
fix(core): remove native bigInt library

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/secp256k1": "^1.3.0",
         "@types/bluebird": "^3.5.32",
         "@types/elliptic": "^6.4.14",
         "@types/jsonwebtoken": "^8.5.6",
@@ -38,10 +37,12 @@
         "@babel/preset-env": "^7.8.0",
         "@babel/preset-typescript": "^7.8.0",
         "@shelf/fast-chunk-string": "^2.0.0",
+        "@types/secp256k1": "^4.0.3",
         "babel-jest": "^27.4.5",
         "del-cli": "^4.0.1",
         "jest": "^27.4.5",
         "mitt": "^3.0.0",
+        "secp256k1": "^4.0.3",
         "typescript": "^4.5.4"
       }
     },
@@ -2427,11 +2428,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.4.0.tgz",
-      "integrity": "sha512-cYpUbQ2uitPgf5QuQnpi8Nu+ZmQjSDunFKw6vvxaOSkbMUhCf4K723WLUuuK1K/sf6H/dvqKbmEAeop5i3qTJg=="
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2645,6 +2641,15 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
+    },
+    "node_modules/@types/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -6853,6 +6858,23 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7702,6 +7724,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "elliptic": "^6.5.4",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/semver": {
@@ -10217,11 +10254,6 @@
       "dev": true,
       "optional": true
     },
-    "@noble/secp256k1": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.4.0.tgz",
-      "integrity": "sha512-cYpUbQ2uitPgf5QuQnpi8Nu+ZmQjSDunFKw6vvxaOSkbMUhCf4K723WLUuuK1K/sf6H/dvqKbmEAeop5i3qTJg=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -10420,6 +10452,15 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
+    },
+    "@types/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -13646,6 +13687,18 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -14239,6 +14292,17 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
+      }
+    },
+    "secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "dev": true,
+      "requires": {
+        "elliptic": "^6.5.4",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
       }
     },
     "semver": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,13 +13,10 @@
   "author": "coolwallet-team",
   "license": "Apache-2.0",
   "dependencies": {
-    "@noble/secp256k1": "^1.3.0",
     "@types/elliptic": "^6.4.14",
+    "@types/lodash": "^4.14.177",
     "@types/node": "^14.0.13",
     "@types/pbkdf2": "^3.1.0",
-    "@types/bluebird": "^3.5.32",
-    "@types/jsonwebtoken": "^8.5.6",
-    "@types/lodash": "^4.14.177",
     "@types/web-bluetooth": "^0.0.11",
     "bip32": "^2.0.4",
     "bip39": "^3.0.2",
@@ -49,10 +46,12 @@
     "@babel/preset-env": "^7.8.0",
     "@babel/preset-typescript": "^7.8.0",
     "@shelf/fast-chunk-string": "^2.0.0",
+    "@types/secp256k1": "^4.0.3",
     "babel-jest": "^27.4.5",
     "del-cli": "^4.0.1",
     "jest": "^27.4.5",
     "mitt": "^3.0.0",
+    "secp256k1": "^4.0.3",
     "typescript": "^4.5.4"
   }
 }


### PR DESCRIPTION
## Summary

Both android JSC and [facebook/Hermes](https://github.com/facebook/hermes) do not support native BigInt.
@noble-secp256k1 is built with native BigInt, so we need to remove it.


