### PR TITLE
feat(core): add getExplicitTxDetail

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/apdu/transaction.ts
+++ b/packages/core/src/apdu/transaction.ts
@@ -58,9 +58,9 @@ export const executeScript = async (transport: Transport, appId: string, appPriv
 
 /**
  * Scriptable step 3.
- * 
+ *
  * Send smart contract data one by one and hash it in card.
- * 
+ *
  * @param transport Transport layer
  * @param appId application id
  * @param appPrivKey application private key
@@ -212,7 +212,7 @@ export const clearTransaction = async (transport: Transport): Promise<boolean> =
 };
 
 /**
- * get Transactino detail shown on hardware.
+ * get transaction detail shown on hardware.
  * @param {Transport} transport
  * @return {Promise<boolean>} true: success, false: canceled.
  */
@@ -226,13 +226,27 @@ export const getTxDetail = async (transport: Transport): Promise<boolean> => {
 };
 
 /**
+ * get transaction detail message and shown on hardware.
+ * @param {Transport} transport
+ * @return {Promise<boolean>} true: success, false: canceled.
+ */
+export const getExplicitTxDetail = async (transport: Transport): Promise<string> => {
+  const { statusCode, msg,outputData } = await executeCommand(transport, commands.GET_TX_DETAIL, target.SE);
+  if (statusCode === CODE._9000) {
+    return outputData;
+  } else {
+    throw new APDUError(commands.GET_TX_DETAIL, statusCode, msg);
+  }
+};
+
+/**
  * set built-in ERC20 token payload in CWS.
  * @param {Transport} transport
  * @param {string} payload
  * @param {number} sn 1: normal erc20, 2: second token in 0x.
  * @return {Promise<boolean>}
  */
-export const setToken = async (transport: Transport, payload: string, sn: number = 1): Promise<boolean> => {
+export const setToken = async (transport: Transport, payload: string, sn = 1): Promise<boolean> => {
   const command = sn === 1 ? commands.SET_ERC20_TOKEN : commands.SET_SECOND_ERC20_TOKEN;
   const { statusCode, msg } = await executeCommand(transport, command, target.SE, payload);
   if (statusCode === CODE._9000) {
@@ -249,7 +263,7 @@ export const setToken = async (transport: Transport, payload: string, sn: number
  * @param {number} sn 1: normal erc20, 2: second token in 0x.
  * @return {Promise<boolean>}
  */
-export const setCustomToken = async (transport: Transport, payload: string, sn: number = 1): Promise<boolean> => {
+export const setCustomToken = async (transport: Transport, payload: string, sn = 1): Promise<boolean> => {
   const command = sn === 1 ? commands.SET_ERC20_TOKEN : commands.SET_SECOND_ERC20_TOKEN;
   const { statusCode, msg } = await executeCommand(transport, command, target.SE, payload, '04', '18');
   if (statusCode === CODE._9000) {

--- a/packages/core/src/config/status/msg.ts
+++ b/packages/core/src/config/status/msg.ts
@@ -25,6 +25,7 @@ export const MSG: CodeList = {
   _6BAC: '',
   _6ED1: 'the data decrypted an incorrect result (PKCS5 check failed, the key may be wrong)',
   _6D63: 'path length is incorrect',
+  _6D64: 'bip32Ed25519 seed is not initialized',
   _6D68: 'path is not standard',
   _6D6C: 'the path of SLIP10 contains non-harden index',
   _6D65: 'path uses unsupported scheme (limited to BIP32 or SLIP10)',


### PR DESCRIPTION
## Summary

- Add create wallet without Cardano seed in `coin-tester`.
- Add `6D64` error message.
- Add `getExplicitTxDetail` to get txDetail string.
