### PR TITLE
fix(core): executeSegmentScript overflow issue

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

P1 and P2 should only contain single-byte information which is not allowed to be greater than 'ff'.
If the argument is too long, it might increase P1 and P2 to two bytes which will cause an APDU command syntax error.
This patch will re-iterate the loop if P1 or P2 is greater than 'ff'.