### PR TITLE
🐛 [CW-13609] fix: react native hermes error by stack size error from ajv module

### DIFF
--- a/packages/coin-avaxc/package.json
+++ b/packages/coin-avaxc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/avaxc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Coolwallet AVAXC sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-avaxc/src/index.ts
+++ b/packages/coin-avaxc/src/index.ts
@@ -440,7 +440,7 @@ export default class AVAXC implements COIN.Coin {
       required: ['types', 'primaryType', 'domain', 'message'],
     };
 
-    const ajv = new Ajv();
+    const ajv = new Ajv({ allErrors: true, inlineRefs: false });
 
     if (!ajv.validate(EIP712Schema, typedData)) {
       throw new Error(ajv.errorsText());

--- a/packages/coin-bsc/package.json
+++ b/packages/coin-bsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/bsc",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Coolwallet BSC sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-bsc/src/sign.ts
+++ b/packages/coin-bsc/src/sign.ts
@@ -8,7 +8,7 @@ import { handleHex } from './utils/stringUtil';
 
 const Web3 = require('web3');
 const Ajv = require('ajv');
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true, inlineRefs: false });
 const typedDataUtils = require('eth-sig-util').TypedDataUtils;
 const rlp = require('rlp');
 

--- a/packages/coin-cronos/package.json
+++ b/packages/coin-cronos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/cronos",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Coolwallet Cronos sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-cronos/src/sign.ts
+++ b/packages/coin-cronos/src/sign.ts
@@ -9,7 +9,7 @@ import * as scriptUtils from './utils/scriptUtils';
 import { handleHex } from './utils/stringUtil';
 import { signMsg, signTyped, EIP712Schema, signTx } from './config/types';
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true, inlineRefs: false });
 
 /**
  * sign ETH Transaction

--- a/packages/coin-eth/package.json
+++ b/packages/coin-eth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/eth",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Coolwallet Ethereum sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-eth/src/sign.ts
+++ b/packages/coin-eth/src/sign.ts
@@ -10,7 +10,7 @@ import * as scriptUtils from './utils/scriptUtils';
 import { handleHex } from './utils/stringUtil';
 import { signMsg, signTyped, EIP712Schema, signTx, signEIP1559Tx } from './config/types';
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true, inlineRefs: false });
 
 export const signEIP1559Transaction = async (
   signTxData: signEIP1559Tx,

--- a/packages/coin-evm/package.json
+++ b/packages/coin-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/evm",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Coolwallet EVMOS sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-evm/src/index.ts
+++ b/packages/coin-evm/src/index.ts
@@ -130,7 +130,7 @@ class Evm extends COIN.ECDSACoin {
   }
 
   async signTypedData(client: Transaction.EIP712TypedDataTransaction): Promise<string> {
-    const ajv = new Ajv();
+    const ajv = new Ajv({ allErrors: true, inlineRefs: false });
     if (!ajv.validate(EIP712Schema, client.typedData)) {
       throw new error.SDKError(this.signTypedData.name, ajv.errorsText());
     }

--- a/packages/coin-matic/package.json
+++ b/packages/coin-matic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/matic",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Coolwallet Polygon sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-matic/src/sign.ts
+++ b/packages/coin-matic/src/sign.ts
@@ -10,7 +10,7 @@ import * as scriptUtils from './utils/scriptUtils';
 import { handleHex } from './utils/stringUtil';
 import { signMsg, signTyped, EIP712Schema, signTx, signEIP1559Tx } from './config/types';
 
-const ajv = new Ajv();
+const ajv = new Ajv({ allErrors: true, inlineRefs: false });
 
 export const signEIP1559Transaction = async (
   signTxData: signEIP1559Tx,


### PR DESCRIPTION
When using hermes, the App will encounter error: Maximum call stack size exceeded.

Refer https://github.com/ajv-validator/ajv/issues/1581#issuecomment-835774241 to resolve this problem

I have tested `@coolwallet/evm` on coin-tester. The `signTypedData` function of it works fine.