### PR TITLE
chore: bump cronos version because v1.1.3 have published before

### DIFF
--- a/packages/coin-cronos/package.json
+++ b/packages/coin-cronos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/cronos",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Coolwallet Cronos sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",


### PR DESCRIPTION
1.1.3 was published 1 years ago. The PR #602 chages are not updated in module `@coolwallet/cronos`
