### PR TITLE
chore: update @coolwallet/dot to 1.1.5

### DIFF
--- a/packages/coin-dot/package.json
+++ b/packages/coin-dot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/dot",
-  "version": "1.1.5-beta.3",
+  "version": "1.1.5",
   "description": "Coolwallet polkadot sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",


### PR DESCRIPTION
1.1.5 had completed DOT Staking feature from CoolWallet QA, so it should be update to stable version.

