### PR TITLE
🔖 [CW-19344] chore: publish coin-bnb 1.1.4

### DIFF
--- a/packages/coin-bnb/package.json
+++ b/packages/coin-bnb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/bnb",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Binance API for CoolWalletS",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
PR: https://github.com/CoolBitX-Technology/coolwallet-sdk/pull/661  is not published because remote module version have been published with v1.1.3