### PR TITLE
[CW-20067] fix(sol): Change isBase58Format check pattern

### DIFF
--- a/packages/coin-sol/src/utils/stringUtil.ts
+++ b/packages/coin-sol/src/utils/stringUtil.ts
@@ -3,12 +3,10 @@ import BN from 'bn.js';
 import * as types from '../config/types';
 
 const HEX_REGEX = /[0-9A-Fa-f]{6}/g;
-const BS58_REGEX = /([G-Z])|([g-z])/g;
 
 export const isBase58Format = (value?: string): boolean => {
   if (!value) return false;
-  const match = value.match(BS58_REGEX);
-  return !!(match && match.length > 0);
+  return /^[A-HJ-NP-Za-km-z1-9]*$/.test(value);
 };
 
 function isHexFormat(value: string): boolean {


### PR DESCRIPTION
----
Changes:

To revise the logic of isBase58Format to prevent issues with Blob encoding encountered by signTransaction.

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
