### PR TITLE
fix: Modified Message.from() for accurate transaction message serialization

### DIFF
--- a/packages/coin-sol/package.json
+++ b/packages/coin-sol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/sol",
-  "version": "1.1.6",
+  "version": "1.1.7-beta.1",
   "description": "Coolwallet Solana sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-sol/src/message/legacy.ts
+++ b/packages/coin-sol/src/message/legacy.ts
@@ -510,8 +510,7 @@ export class Message {
     for (let i = 0; i < accountCount; i++) {
       const account = byteArray.slice(0, PUBLIC_KEY_LENGTH);
       byteArray = byteArray.slice(PUBLIC_KEY_LENGTH);
-      // accountKeys.push(new PublicKey(Buffer.from(account)));
-      accountKeys.push(bs58.encode(Buffer.from(account)));
+      accountKeys.push(Buffer.from(account).toString('hex'));
     }
 
     const recentBlockhash = byteArray.slice(0, PUBLIC_KEY_LENGTH);
@@ -526,7 +525,7 @@ export class Message {
       byteArray = byteArray.slice(instructionAccountCount);
       const dataLength = shortvec.decodeLength(byteArray);
       const dataSlice = byteArray.slice(0, dataLength);
-      const data = bs58.encode(Buffer.from(dataSlice));
+      const data = Buffer.from(dataSlice).toString('hex');
       byteArray = byteArray.slice(dataLength);
       instructions.push({
         programIdIndex,
@@ -541,7 +540,7 @@ export class Message {
         numReadonlySignedAccounts,
         numReadonlyUnsignedAccounts,
       },
-      recentBlockhash: bs58.encode(Buffer.from(recentBlockhash)),
+      recentBlockhash: Buffer.from(recentBlockhash).toString('hex'),
       accountKeys,
       instructions,
     };

--- a/packages/coin-sol/src/sign.ts
+++ b/packages/coin-sol/src/sign.ts
@@ -53,19 +53,14 @@ async function signTransaction(
   script: string,
   argument: string
 ): Promise<string> {
-  const signature = await executeScriptWithPreActions(signTxData, script, argument);
+  const signature = await executeScriptWithPreActions(signTxData, script, argument) as Buffer;
 
-  if (rawTx instanceof Message || rawTx instanceof MessageV0) {
-    let signatureUint8Array: Uint8Array;
-    if (signature instanceof Buffer) {
-      signatureUint8Array = new Uint8Array(signature);
-    } else {
-      const rBuffer = Buffer.from(signature.r, 'hex');
-      const sBuffer = Buffer.from(signature.s, 'hex');
-      signatureUint8Array = new Uint8Array([...rBuffer, ...sBuffer]);
-    }
-    return new VersionedTransaction(rawTx, [signatureUint8Array]).serialize().toString();
-  }else if (rawTx instanceof Transaction){
+  if(rawTx instanceof Message|| rawTx instanceof MessageV0){
+    const signatureUint8Array = new Uint8Array(signature);
+    const serializedTransaction = new VersionedTransaction(rawTx, [signatureUint8Array]).serialize();
+    return  Buffer.from(serializedTransaction).toString('hex');
+  }
+  else if (rawTx instanceof Transaction){
     return rawTx.toTxString(signature.toString('hex'));
   }else{
     throw new Error('Invalid transaction type');


### PR DESCRIPTION
----
*Testing Result:* passed

```
const rawTx = 
'01000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100010246a448fb09aea355ea540c1e2e86127d4795a86a533a977e20f5476f5bd100a5054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d46f62fe8ed25e2ed67188596d19735fc0679d8c917d1589ea412d5b97f145b7d0101003248656c6c6f2c2066726f6d2074686520536f6c616e612057616c6c65742041646170746572206578616d706c652061707021'

const versionedTransaction:VersionedTransaction =  
VersionedTransaction.deserialize(new Uint8Array(Buffer.from(rawTx,'hex')))

  const signData = {
    addressIndex: 0, 
    transaction: versionedTransaction,
    transport: {} as any,
    appPrivateKey: 'abc',
    appId: '123',
    confirmCB(): void {
      // Method is intentionally left blank
    },
    authorizedCB(): void {
      // Method is intentionally left blank
    },
  }

  const argument = new SolanaSDK().signTransaction(signData);
```
Output argument =
`11108000002c800001f580000000800000000100010246a448fb09aea355ea540c1e2e86127d4795a86a533a977e20f5476f5bd100a5054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d46f62fe8ed25e2ed67188596d19735fc0679d8c917d1589ea412d5b97f145b7d0101003248656c6c6f2c2066726f6d2074686520536f6c616e612057616c6c65742041646170746572206578616d706c652061707021`

Given mockedSignature = `d7cdfab2769e8b8413d1cc389c8bb1cc3ecf5f7f3ef064dd483f9bf8e42afb3a85d5d64062d56e59d2c1178c36a540e9f20eb9cc8b2553f039618f9a2e9c400e`

Output signedData = 
`01d7cdfab2769e8b8413d1cc389c8bb1cc3ecf5f7f3ef064dd483f9bf8e42afb3a85d5d64062d56e59d2c1178c36a540e9f20eb9cc8b2553f039618f9a2e9c400e0100010246a448fb09aea355ea540c1e2e86127d4795a86a533a977e20f5476f5bd100a5054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d46f62fe8ed25e2ed67188596d19735fc0679d8c917d1589ea412d5b97f145b7d0101003248656c6c6f2c2066726f6d2074686520536f6c616e612057616c6c65742041646170746572206578616d706c652061707021`

**Transaction Structure**
```
> version
01
> signature
d7cdfab2769e8b8413d1cc389c8bb1cc3ecf5f7f3ef064dd483f9bf8e42afb3a85d5d64062d56e59d2c1178c36a540e9f20eb9cc8b2553f039618f9a2e9c400e
> numRequiredSignatures
01
> numReadonlySignedAccounts
00
> numReadonlyUnsignedAccounts
01
> keyCount
02
> keys
46a448fb09aea355ea540c1e2e86127d4795a86a533a977e20f5476f5bd100a5
054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d
> recentBlockHash
46f62fe8ed25e2ed67188596d19735fc0679d8c917d1589ea412d5b97f145b7d
> instructions{...}
010100
> dataLength
32
> Hello, from the Solana Wallet Adapter example app!
48656c6c6f2c2066726f6d2074686520536f6c616e612057616c6c65742041646170746572206578616d706c652061707021
```

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
