### PR TITLE
🐛 fix: user cannot send SPL token if its symbol length is greater than 7

### DIFF
--- a/packages/coin-sol/package-lock.json
+++ b/packages/coin-sol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/sol",
-  "version": "1.1.9-beta.1",
+  "version": "1.1.9-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/sol",
-      "version": "1.1.9-beta.1",
+      "version": "1.1.9-beta.2",
       "license": "ISC",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",

--- a/packages/coin-sol/package.json
+++ b/packages/coin-sol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/sol",
-  "version": "1.1.9-beta.1",
+  "version": "1.1.9-beta.2",
   "description": "Coolwallet Solana sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-sol/src/utils/scriptUtil.ts
+++ b/packages/coin-sol/src/utils/scriptUtil.ts
@@ -26,7 +26,7 @@ function getTokenInfoArgs(tokenInfo: types.TokenInfo): string {
   const tokenSignature = tokenInfo.signature ?? '';
   const signature = tokenSignature.slice(82).padStart(144, '0');
   const tokenInfoToHex = Buffer.from([+tokenInfo.decimals, tokenInfo.symbol.length]).toString('hex');
-  const tokenSymbol = Buffer.from(tokenInfo.symbol.toUpperCase()).toString('hex').padEnd(14, '0');
+  const tokenSymbol = Buffer.from(tokenInfo.symbol.slice(0, 7).toUpperCase()).toString('hex').padEnd(14, '0');
   const tokenPublicKey = Buffer.from(base58.decode(tokenInfo.address)).toString('hex');
 
   return tokenInfoToHex + tokenSymbol + tokenPublicKey + signature;


### PR DESCRIPTION
- **fix: 6ae2 if user is sending token which symbol length is greater than 7**
- **chore: execute 'npm install'**
