### PR TITLE
feat(transport-react-native-nfc): support nfc transceive data more then 251 bytes

### DIFF
--- a/packages/transport-react-native-nfc/package-lock.json
+++ b/packages/transport-react-native-nfc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/transport-react-native-nfc",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "^2.0.0-beta.2",

--- a/packages/transport-react-native-nfc/package.json
+++ b/packages/transport-react-native-nfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/transport-react-native-nfc/src/utils.ts
+++ b/packages/transport-react-native-nfc/src/utils.ts
@@ -38,7 +38,9 @@ function decodeCommand(command: string): APDUCommand {
 
 function encodeApdu(cla: number, ins: number, p1: number, p2: number, data: string): number[] {
   const dataBytes = hexStringToNumberArray(data);
-  return [cla, ins, p1, p2, dataBytes.length, ...dataBytes];
+  const dataLengthBytes =  hexStringToNumberArray(dataBytes.length.toString(16).padStart(6, '0'));
+
+  return [cla, ins, p1, p2, ...dataLengthBytes, ...dataBytes];
 }
 
 export { decodeCommand, encodeApdu, numberArrayToHexString, hexStringToNumberArray };


### PR DESCRIPTION
support nfc transceive data more then 251 bytes.