### PR TITLE
🔨 chore: add script to install test fixture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,9 +1789,9 @@
       "dev": true
     },
     "node_modules/@coolwallet/core": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.10.tgz",
-      "integrity": "sha512-NUsNj2nr6gaBoVZ9H7ydMWADZZXXJ2IcJRu2QzU0xJ8WF7igXx0TeMq+tmkh2hKfBOue8fmeEaaehe337AOHQw==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.27.tgz",
+      "integrity": "sha512-mA0HMH7vOfvY8zf/TmwIIxwpn+9f11Wl4//jwDtBCG6u0b0/NGifeDJvoE0Bt5NleQ0loNUvZK9hMPLQQRY0Xw==",
       "dev": true,
       "dependencies": {
         "@types/elliptic": "^6.4.14",
@@ -16365,6 +16365,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@coolwallet/core": "^1.1.26",
         "@noble/ed25519": "^1.6.0",
         "@noble/hashes": "^1.0.0",
         "@noble/secp256k1": "^1.5.5",
@@ -16376,14 +16377,10 @@
         "@babel/core": "^7.17.9",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-typescript": "^7.16.7",
-        "@coolwallet/core": "^1.1.7",
         "bs58check": "^2.1.2",
         "del-cli": "^4.0.1",
         "jest": "^27.5.1",
         "typescript": "^4.6.3"
-      },
-      "peerDependencies": {
-        "@coolwallet/core": "^1.1.7"
       }
     },
     "packages/transport-jre-http": {
@@ -17635,9 +17632,9 @@
       "dev": true
     },
     "@coolwallet/core": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.10.tgz",
-      "integrity": "sha512-NUsNj2nr6gaBoVZ9H7ydMWADZZXXJ2IcJRu2QzU0xJ8WF7igXx0TeMq+tmkh2hKfBOue8fmeEaaehe337AOHQw==",
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.27.tgz",
+      "integrity": "sha512-mA0HMH7vOfvY8zf/TmwIIxwpn+9f11Wl4//jwDtBCG6u0b0/NGifeDJvoE0Bt5NleQ0loNUvZK9hMPLQQRY0Xw==",
       "dev": true,
       "requires": {
         "@types/elliptic": "^6.4.14",
@@ -17673,7 +17670,7 @@
         "@babel/core": "^7.17.9",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-typescript": "^7.16.7",
-        "@coolwallet/core": "^1.1.7",
+        "@coolwallet/core": "^1.1.26",
         "@noble/ed25519": "^1.6.0",
         "@noble/hashes": "^1.0.0",
         "@noble/secp256k1": "^1.5.5",

--- a/scripts/install-test-fixture.sh
+++ b/scripts/install-test-fixture.sh
@@ -1,0 +1,5 @@
+TEST_FIXTURE_SCOPES="--scope @coolwallet/core --scope @coolwallet/testing-library --scope @coolwallet/transport-jre-http"
+LERNA="npx lerna"
+
+$LERNA bootstrap $TEST_FIXTURE_SCOPES
+$LERNA run build $TEST_FIXTURE_SCOPES


### PR DESCRIPTION
Before running unit test. You can run `sh ./scripts/install-test-fixture.sh` at project root to prepare test fixture