### PR TITLE
fix(kas): 修正 readme 中的 name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Used to sign transactions of different cryptocurrencies.
 | [`@coolwallet/eth`](/packages/coin-eth)   | ![version](https://img.shields.io/npm/v/@coolwallet/eth) | Ethereum |
 | [`@coolwallet/evm`](/packages/coin-evm)   | ![version](https://img.shields.io/npm/v/@coolwallet/evm) | Some EVM coins |
 | [`@coolwallet/icx`](/packages/coin-icx)   | ![version](https://img.shields.io/npm/v/@coolwallet/icx) | Icon |
-| [`@coolwallet/kas`](/packages/coin-kas)   | ![version](https://img.shields.io/npm/v/@coolwallet/kas) | Icon |
+| [`@coolwallet/kas`](/packages/coin-kas)   | ![version](https://img.shields.io/npm/v/@coolwallet/kas) | Kaspa |
 | [`@coolwallet/ltc`](/packages/coin-ltc)   | ![version](https://img.shields.io/npm/v/@coolwallet/ltc) | LiteCoin |
 | [`@coolwallet/sol`](/packages/coin-sol)   | ![version](https://img.shields.io/npm/v/@coolwallet/sol) | Solana |
 | [`@coolwallet/ton`](/packages/coin-ton)   | ![version](https://img.shields.io/npm/v/@coolwallet/ton) | The Open Network |


### PR DESCRIPTION
**PR Summary by Typo**
------------

 **Summary:**
- Updated `@coolwallet/kas` package README.md to change the coin icon name from "Icon" to "Kaspa".

**Key points:**
- Modified the README.md file.
- Changed the coin name for `@coolwallet/kas` package.

**Changes:**
1. **README.md:**
   - Updated the coin name for `@coolwallet/kas` in the list of packages.
**Impact:**
- The visual representation of the `@coolwallet/kas` package in various platforms will now display "Kaspa" instead of "Icon".

**Tools:**
- README.md file editor.

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>