### PR TITLE
[CW-21695] 🐛  fix: move web3-utils from devDependencies to dependencies to fix evm token connot transfer issue

### DIFF
--- a/packages/coin-evm/package-lock.json
+++ b/packages/coin-evm/package-lock.json
@@ -16,7 +16,8 @@
         "elliptic": "^6.5.4",
         "keccak": "^3.0.2",
         "lodash": "^4.17.21",
-        "rlp": "^3.0.0"
+        "rlp": "^3.0.0",
+        "web3-utils": "^1.7.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.6",
@@ -33,8 +34,7 @@
         "del-cli": "^4.0.1",
         "ethereumjs-util": "^7.1.4",
         "printf": "^0.6.1",
-        "typescript": "^4.6.2",
-        "web3-utils": "^1.7.1"
+        "typescript": "^4.6.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/@coolwallet/core": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0-beta.14.tgz",
-      "integrity": "sha512-4wE5FeTgxVS6ElQxE+J/I6jb8fDLVDvvq1H3HRVulDaH0ILXqACFh9w9crzqWy6eeBuEeB09Ng8UlaxIVvyHtA==",
+      "version": "2.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0-beta.15.tgz",
+      "integrity": "sha512-+TZY9kL/sqiKPABcSyx/j3JfyW0jR6E9Ey8FLHhco+zWCKJ3eAZUCzImWOxexZJ+xN9XcR/4ZxT4jn+rJkxe7w==",
       "dependencies": {
         "@types/elliptic": "^6.4.14",
         "@types/lodash": "^4.14.177",
@@ -2810,7 +2810,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
       "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dev": true,
       "dependencies": {
         "js-sha3": "^0.8.0"
       }
@@ -2893,7 +2892,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
       "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-      "dev": true,
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -2909,7 +2907,6 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
       "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-      "dev": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       },
@@ -2921,7 +2918,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-      "dev": true,
       "dependencies": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -2934,8 +2930,7 @@
     "node_modules/ethjs-unit/node_modules/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-      "dev": true
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -3625,8 +3620,7 @@
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "dev": true
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4001,7 +3995,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
       "dependencies": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -4014,8 +4007,7 @@
     "node_modules/number-to-bn/node_modules/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-      "dev": true
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
     },
     "node_modules/object-inspect": {
       "version": "1.12.0",
@@ -5056,8 +5048,7 @@
     "node_modules/utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -5090,7 +5081,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
       "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "ethereum-bloom-filters": "^1.0.6",
@@ -5107,8 +5097,7 @@
     "node_modules/web3-utils/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
@@ -6333,9 +6322,9 @@
       }
     },
     "@coolwallet/core": {
-      "version": "2.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0-beta.14.tgz",
-      "integrity": "sha512-4wE5FeTgxVS6ElQxE+J/I6jb8fDLVDvvq1H3HRVulDaH0ILXqACFh9w9crzqWy6eeBuEeB09Ng8UlaxIVvyHtA==",
+      "version": "2.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0-beta.15.tgz",
+      "integrity": "sha512-+TZY9kL/sqiKPABcSyx/j3JfyW0jR6E9Ey8FLHhco+zWCKJ3eAZUCzImWOxexZJ+xN9XcR/4ZxT4jn+rJkxe7w==",
       "requires": {
         "@types/elliptic": "^6.4.14",
         "@types/lodash": "^4.14.177",
@@ -7228,7 +7217,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
       "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dev": true,
       "requires": {
         "js-sha3": "^0.8.0"
       }
@@ -7312,7 +7300,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.4.tgz",
       "integrity": "sha512-p6KmuPCX4mZIqsQzXfmSx9Y0l2hqf+VkAiwSisW3UKUFdk8ZkAt+AYaor83z2nSi6CU2zSsXMlD80hAbNEGM0A==",
-      "dev": true,
       "requires": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -7325,7 +7312,6 @@
           "version": "2.2.7",
           "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
           "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-          "dev": true,
           "requires": {
             "bn.js": "^5.2.0"
           }
@@ -7336,7 +7322,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -7345,8 +7330,7 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -7848,8 +7832,7 @@
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "dev": true
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -8147,7 +8130,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -8156,8 +8138,7 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -8905,8 +8886,7 @@
     "utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -8936,7 +8916,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.3.tgz",
       "integrity": "sha512-g6nQgvb/bUpVUIxJE+ezVN+rYwYmlFyMvMIRSuqpi1dk6ApDD00YNArrk7sPcZnjvxOJ76813Xs2vIN2rgh4lg==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "ethereum-bloom-filters": "^1.0.6",
@@ -8950,8 +8929,7 @@
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },

--- a/packages/coin-evm/package.json
+++ b/packages/coin-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Coolwallet EVMOS sdk",
   "main": "lib/index.js",
   "scripts": {
@@ -38,8 +38,7 @@
     "del-cli": "^4.0.1",
     "ethereumjs-util": "^7.1.4",
     "printf": "^0.6.1",
-    "typescript": "^4.6.2",
-    "web3-utils": "^1.7.1"
+    "typescript": "^4.6.2"
   },
   "dependencies": {
     "@coolwallet/core": "^2.0.0-beta.14",
@@ -49,7 +48,8 @@
     "elliptic": "^6.5.4",
     "keccak": "^3.0.2",
     "lodash": "^4.17.21",
-    "rlp": "^3.0.0"
+    "rlp": "^3.0.0",
+    "web3-utils": "^1.7.1"
   },
   "jest": {
     "setupFilesAfterEnv": [


### PR DESCRIPTION
- move web3-utils from devDependencies to dependencies to fix evm token connot transfer issue
- 有 local 測試過 Polygon, Polygon USDT, Arbitrum USDT 都可以正常發送
----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

 **Summary:**
This pull request updates package versions and checksums for `@coolwallet/core` and several dependencies. Some dependencies have the `dev` flag removed.

**Key Points:**

1. Updates package versions and checksums for `@coolwallet/core` and dependencies.
2. Removes `dev` flag for certain dependencies.
3. Affects multiple projects, including `coin-evm`.
4. Updates `utf8`, `util-deprecate`, and `web3-utils` packages for `coin-evm`.
5. Removes SHA-1 integrity for `utf8` and adds SHA-512 integrity for `util-deprecate` and `bn.js`.
6. Bumps version of `typescript` to 4.6.2 for `coin-evm`. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>