### PR TITLE
💚 fix(bsc): publish failed by `npm run build`

### DIFF
--- a/packages/coin-bsc/tsconfig.json
+++ b/packages/coin-bsc/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src/**/*"],
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

Updated `tsconfig.json` in `coin-bsc` to include all `src` files for TypeScript compilation.

**Key Points**

1. Expanded `tsconfig.json` coverage in `coin-bsc`.
2. Included all `src` files for TypeScript compilation.
3. Previous configuration only had basic options. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>