### PR TITLE
🐛 fix(core): firmware update failed because ssd applet not support 3 bytes data length 

### DIFF
--- a/packages/transport-react-native-nfc/package-lock.json
+++ b/packages/transport-react-native-nfc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/transport-react-native-nfc",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "^2.0.0-beta.2",

--- a/packages/transport-react-native-nfc/package.json
+++ b/packages/transport-react-native-nfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/transport-react-native-nfc/src/utils.ts
+++ b/packages/transport-react-native-nfc/src/utils.ts
@@ -38,7 +38,9 @@ function decodeCommand(command: string): APDUCommand {
 
 function encodeApdu(cla: number, ins: number, p1: number, p2: number, data: string): number[] {
   const dataBytes = hexStringToNumberArray(data);
-  const dataLengthBytes =  hexStringToNumberArray(dataBytes.length.toString(16).padStart(6, '0'));
+  const dataLengthBytes = hexStringToNumberArray(
+    dataBytes.length.toString(16).padStart(Buffer.from(data, 'hex').byteLength >= 256 ? 6 : 2, '0') // apdu command support 1 bytes or 3 bytes data length.
+  );
 
   return [cla, ins, p1, p2, ...dataLengthBytes, ...dataBytes];
 }


### PR DESCRIPTION
in generally, apdu command can bring 3 bytes to describe data length, please refer to: [apdu lc](https://zh.wikipedia.org/zh-tw/%E6%99%BA%E8%83%BD%E5%8D%A1%E5%BA%94%E7%94%A8%E5%8D%8F%E8%AE%AE%E6%95%B0%E6%8D%AE%E5%8D%95%E5%85%83#:~:text=%E8%99%95%E5%AF%AB%E5%85%A5%E6%95%B8%E6%93%9A-,Lc,-0%2C%201%20%E6%88%96)

but do firmware update failed, because our lite card's ssd applet only support 1 bytes data length.

test firmware update on app e2e. ✅
 
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates package versions to beta.5 for `@coolwallet/transport-react-native-nfc` and modifies `utils.ts` for APDU command length handling.

**Key Points**

1. Upgrades package versions in `package-lock.json` and `package.json` to beta.5.
2. Modifies `utils.ts` for handling 1 or 3 bytes length in APDU commands. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>