### PR TITLE
feat(coin-kas): check pubkey is correct in decodeAddress

### DIFF
--- a/packages/coin-kas/package-lock.json
+++ b/packages/coin-kas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/kas",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/kas",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",

--- a/packages/coin-kas/package.json
+++ b/packages/coin-kas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/kas",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Coolwallet Kaspa sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-kas/src/utils/__test__/address.test.ts
+++ b/packages/coin-kas/src/utils/__test__/address.test.ts
@@ -1,4 +1,4 @@
-import { addressToOutScript, getAddressByPublicKey, pubkeyToPayment } from '../address';
+import { addressToOutScript, decodeAddress, getAddressByPublicKey, pubkeyToPayment } from '../address';
 
 describe('Test address.ts', () => {
   it('Test getAddressByPublicKey', async () => {
@@ -101,5 +101,17 @@ describe('Test address.ts', () => {
         },
       }
     `);
+  });
+
+  it('Test decodeAddress throws error if address is different between decodeAddress and getAddressByPublicKey', () => {
+    try {
+      const address = 'kaspa:qyp2d6tctf8wkahskz4hv3xpe3llknrc3jl66798elnjvr2gewzrdggx6fnfh3y';
+      decodeAddress(address);
+      fail('Expected error to be thrown');
+    } catch (error) {
+      expect(error).toMatchInlineSnapshot(
+        `[Error: error function: decodeAddress, message: Wrong public key from address: kaspa:qyp2d6tctf8wkahskz4hv3xpe3llknrc3jl66798elnjvr2gewzrdggx6fnfh3y]`
+      );
+    }
   });
 });

--- a/packages/coin-kas/src/utils/address.ts
+++ b/packages/coin-kas/src/utils/address.ts
@@ -79,6 +79,7 @@ export function decodeAddress(address: string) {
 
   const convertedBits = convert(payload.slice(0, -8), 5, 8, true);
   const versionByte = convertedBits[0];
+
   const hashOrPublicKey = convertedBits.slice(1);
   const bitLength = getBitLength(hashOrPublicKey);
 
@@ -90,8 +91,15 @@ export function decodeAddress(address: string) {
 
   const type = getType(versionByte);
 
+  const hashOrPublicKeyBuffer = Buffer.from(hashOrPublicKey);
+  validate(
+    getAddressByPublicKey(hashOrPublicKeyBuffer.toString('hex')) === address,
+    decodeAddress.name,
+    'Wrong public key from address: ' + address
+  );
+
   return {
-    payload: Buffer.from(hashOrPublicKey),
+    payload: hashOrPublicKeyBuffer,
     prefix,
     type,
   };


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates package versions and adds a new test case (Version update and Testing), modifies a function's return type (Type modification).

**Key Points**

* Updates "@coolwallet/kas" package versions in package-lock.json and package.json
* Adds a test case in address.test.ts to validate address decoding
* Modifies a function's return type from Buffer object to Buffer variable `hashOrPublicKeyBuffer` 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>