### PR TITLE
feat(transport): add error handler in NFCTransport

### DIFF
--- a/packages/transport-react-native-nfc/package-lock.json
+++ b/packages/transport-react-native-nfc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/transport-react-native-nfc",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "^2.0.0-beta.2",

--- a/packages/transport-react-native-nfc/package.json
+++ b/packages/transport-react-native-nfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates package versions and adds error listener functionality to `NFCTransport` class.

**Key Points**

* Updates package versions in `package-lock.json` and `package.json` to `beta.6`.
* Adds error listener to `NFCTransport` class for registering and removing error callbacks. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>