### PR TITLE
fix(core): CW-22295 length of s in canonical signature must be 32 bytes

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.29",
+  "version": "1.1.30-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "1.1.29",
+      "version": "1.1.30-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.29",
+  "version": "1.1.30-beta.0",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/crypto/signature.ts
+++ b/packages/core/src/crypto/signature.ts
@@ -9,7 +9,7 @@ export const parseDERsignature = (signature: string) => {
   const decoded = bip66.decode(Buffer.from(signature, 'hex'));
   const obj = {
     r: decoded.r.toString('hex'),
-    s: decoded.s.toString('hex')
+    s: decoded.s.toString('hex'),
   };
   return obj;
 };
@@ -44,25 +44,24 @@ export const getCanonicalSignature = (signature: { s?: any; r?: any }) => {
   const modulus = new BN(modulusString, 16);
   const s = new BN(signature.s, 16);
   const r = new BN(signature.r, 16);
-  const T = modulus.sub(s);
+  const t = modulus.sub(s);
 
+  // bigNumber will cause s.length changed, so we need to pad it to 64 (string length which is equal to 32 bytes)
   let canonicalS;
-  if (s.ucmp(T) < 0) {
+  if (s.ucmp(t) < 0) {
     canonicalS = s.toString(16);
   } else {
-    canonicalS = T.toString(16);
+    canonicalS = t.toString(16);
   }
 
-  const slength = canonicalS.length % 2 === 0 ? canonicalS.length : canonicalS.length + 1;
-  canonicalS = canonicalS.padStart(slength, '0');
+  canonicalS = canonicalS.padStart(64, '0');
   const rBigNumber = r.toString(16);
 
-  const rlength = rBigNumber.length % 2 === 0 ? rBigNumber.length : rBigNumber.length + 1;
-  const canonicalR = rBigNumber.padStart(rlength, '0');
+  const canonicalR = rBigNumber.padStart(64, '0');
 
   const canonicalSignature = {
     r: canonicalR,
-    s: canonicalS
+    s: canonicalS,
   };
 
   return canonicalSignature;


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates package versions to `1.1.30-beta.0` and pads signature strings in `getCanonicalSignature` function.

**Key Points**

* Updates package versions to `1.1.30-beta.0` in `package-lock.json` and `package.json`.
* Pads `canonicalS` and `canonicalR` strings in `getCanonicalSignature` to 64 characters long. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>