### PR TITLE
🐛  [CW-22295] fix: dot test failed

### DIFF
--- a/packages/coin-dot/package-lock.json
+++ b/packages/coin-dot/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/dot",
-  "version": "1.1.7",
+  "version": "1.1.8.beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/dot",
-      "version": "1.1.7",
+      "version": "1.1.8.beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/keyring": "^6.0.5",
@@ -20,7 +20,7 @@
         "@babel/plugin-proposal-class-properties": "^7.7.4",
         "@babel/preset-env": "^7.7.1",
         "@babel/preset-typescript": "^7.7.7",
-        "@coolwallet/core": "^1.1.1"
+        "@coolwallet/core": "^1.1.30-beta.1"
       },
       "peerDependencies": {
         "@coolwallet/core": "^1.1.1"
@@ -1473,15 +1473,12 @@
       }
     },
     "node_modules/@coolwallet/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-fLCedrv9KD0aN4bJJG7576OCe+Gg3C4bEmdvKNJE/8t56/1W3saQ/W3FYi32EnPw8y0Jg+zbQyqCp1O29c246g==",
+      "version": "1.1.30-beta.1",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.30-beta.1.tgz",
+      "integrity": "sha512-aLdfzcDHjG5USfa+dOx9vP8mZwMsSIBrrZSmkCeoWb5UOdJvZ1ExhLHcOMDKpiIct5b/MTV8/YZG0O3KLTwLfA==",
       "dev": true,
       "dependencies": {
-        "@noble/secp256k1": "^1.3.0",
-        "@types/bluebird": "^3.5.32",
         "@types/elliptic": "^6.4.14",
-        "@types/jsonwebtoken": "^8.5.6",
         "@types/lodash": "^4.14.177",
         "@types/node": "^14.0.13",
         "@types/pbkdf2": "^3.1.0",
@@ -1491,7 +1488,6 @@
         "bip66": "^1.1.5",
         "bn.js": "^5.1.1",
         "elliptic": "^6.5.3",
-        "jose": "^4.3.7",
         "jwt-decode": "^3.1.2",
         "key-encoder": "^2.0.3",
         "lodash": "^4.17.21",
@@ -1519,18 +1515,6 @@
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
       }
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
-      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
     },
     "node_modules/@polkadot/keyring": {
       "version": "6.3.1",
@@ -1695,12 +1679,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "dev": true
-    },
     "node_modules/@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -1716,15 +1694,6 @@
       "dev": true,
       "dependencies": {
         "@types/bn.js": "*"
-      }
-    },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
-      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/lodash": {
@@ -3470,15 +3439,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jose": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.5.1.tgz",
-      "integrity": "sha512-uhjuzZjKGKmi5DVJ/eghN8hJklLhwZRLRAaaG9MkkMAdfRYlHvZ10i4z/4WSN1hSTMffCet+k7iRHvbdGwmZPw==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-sha3": {
@@ -5997,15 +5957,12 @@
       }
     },
     "@coolwallet/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-fLCedrv9KD0aN4bJJG7576OCe+Gg3C4bEmdvKNJE/8t56/1W3saQ/W3FYi32EnPw8y0Jg+zbQyqCp1O29c246g==",
+      "version": "1.1.30-beta.1",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-1.1.30-beta.1.tgz",
+      "integrity": "sha512-aLdfzcDHjG5USfa+dOx9vP8mZwMsSIBrrZSmkCeoWb5UOdJvZ1ExhLHcOMDKpiIct5b/MTV8/YZG0O3KLTwLfA==",
       "dev": true,
       "requires": {
-        "@noble/secp256k1": "^1.3.0",
-        "@types/bluebird": "^3.5.32",
         "@types/elliptic": "^6.4.14",
-        "@types/jsonwebtoken": "^8.5.6",
         "@types/lodash": "^4.14.177",
         "@types/node": "^14.0.13",
         "@types/pbkdf2": "^3.1.0",
@@ -6015,7 +5972,6 @@
         "bip66": "^1.1.5",
         "bn.js": "^5.1.1",
         "elliptic": "^6.5.3",
-        "jose": "^4.3.7",
         "jwt-decode": "^3.1.2",
         "key-encoder": "^2.0.3",
         "lodash": "^4.17.21",
@@ -6043,12 +5999,6 @@
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
       }
-    },
-    "@noble/secp256k1": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
-      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
-      "dev": true
     },
     "@polkadot/keyring": {
       "version": "6.3.1",
@@ -6182,12 +6132,6 @@
         "@polkadot/x-global": "6.3.1"
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.36",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
-      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
-      "dev": true
-    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -6203,15 +6147,6 @@
       "dev": true,
       "requires": {
         "@types/bn.js": "*"
-      }
-    },
-    "@types/jsonwebtoken": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
-      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/lodash": {
@@ -7664,12 +7599,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true,
       "optional": true
-    },
-    "jose": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.5.1.tgz",
-      "integrity": "sha512-uhjuzZjKGKmi5DVJ/eghN8hJklLhwZRLRAaaG9MkkMAdfRYlHvZ10i4z/4WSN1hSTMffCet+k7iRHvbdGwmZPw==",
-      "dev": true
     },
     "js-sha3": {
       "version": "0.8.0",

--- a/packages/coin-dot/package.json
+++ b/packages/coin-dot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/dot",
-  "version": "1.1.7",
+  "version": "1.1.8.beta.0",
   "description": "Coolwallet polkadot sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",
@@ -28,7 +28,7 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-typescript": "^7.7.7",
-    "@coolwallet/core": "^1.1.1"
+    "@coolwallet/core": "1.1.30-beta.1"
   },
   "repository": {
     "type": "git",

--- a/packages/coin-dot/package.json
+++ b/packages/coin-dot/package.json
@@ -28,7 +28,7 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-typescript": "^7.7.7",
-    "@coolwallet/core": "1.1.30-beta.1"
+    "@coolwallet/core": "^1.1.30-beta.1"
   },
   "repository": {
     "type": "git",

--- a/packages/coin-dot/src/utils/transactionUtil.ts
+++ b/packages/coin-dot/src/utils/transactionUtil.ts
@@ -25,12 +25,18 @@ export function pubKeyToAddress(compressedPubkey: string, addressType: number): 
 export async function getCompleteSignature(
   transport: types.Transport,
   publicKey: string,
-  canonicalSignature: { r: string; s: string } | Buffer
+  canonicalSignature: { r: string; s: string; s32?: string } | Buffer
 ): Promise<string> {
   if (Buffer.isBuffer(canonicalSignature)) {
     return '';
   }
-  const { r, s } = canonicalSignature;
+  const { r, s32 } = canonicalSignature;
+
+  if (s32 === undefined) {
+    throw new Error('utils.transactionUtil.getCompleteSignature: s32 is undefined');
+  }
+
+  const s = s32;
   const { signedTx } = await apdu.tx.getSignedHex(transport);
   const keyPair = ec.keyFromPublic(publicKey, 'hex');
   const payloaBlake2bHash = blake2b(signedTx);

--- a/packages/coin-eth/tests/index.spec.ts
+++ b/packages/coin-eth/tests/index.spec.ts
@@ -18,7 +18,7 @@ describe('Test ETH SDK', () => {
   let transport: Transport;
   const wallet = new Wallet();
   const eth = new ETH();
-  const mnemonic = bip39.generateMnemonic();
+  const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo abstract';
 
   beforeAll(async () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/core/src/transaction/txUtil.ts
+++ b/packages/core/src/transaction/txUtil.ts
@@ -14,7 +14,7 @@ export const decryptSignatureFromSE = (
   encryptedSignature: string,
   signatureKey: string,
   signatureType: SignatureType
-): { r: string; s: string } | Buffer => {
+): { r: string; s: string; s32?: string } | Buffer => {
   const iv = Buffer.alloc(16);
   iv.fill(0);
   const sigBuff = aes256CbcDecrypt(iv, Buffer.from(signatureKey, 'hex'), encryptedSignature);


### PR DESCRIPTION
此 pr 主要更新 core 版本，並且修正 dot 在組交易時使用 s32 來組，避免交易遇到 bad signature 導致交易失敗

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

 **Summary:**
This pull request includes updates to package versions, mnemonic phrase, and signature decryption in the Eth SDK.

**Key Points:**

1. Fixed mnemonic phrase in Eth SDK tests.
2. Added `s32` value when decrypting signature from SE in `txUtil.ts`.
3. Updated packages and dependencies, including "@coolwallet/core", "@types/bn.js", "jose", "types/bluebird", and "js-sha3". 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>