### PR TITLE
🐛 fix: gcloud not found error

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -23,7 +23,7 @@ jobs:
         token: ${{ secrets.DEVOPS_READ_PACKAGE_TOKEN }}
 
     - name: Authenticate gcloud
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
@@ -53,6 +53,9 @@ jobs:
         MODIFIED_COINS=$(echo $MODIFIED_COINS | xargs)  # Trim leading/trailing whitespace
         echo "modified_coins=$MODIFIED_COINS" >> $GITHUB_OUTPUT
 
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2  
+            
     - name: Docker auth
       run: gcloud auth configure-docker ${{ env.REGISTRY }}
 

--- a/.github/workflows/test-and-generate-report.yml
+++ b/.github/workflows/test-and-generate-report.yml
@@ -24,7 +24,7 @@ jobs:
         token: ${{ secrets.DEVOPS_READ_PACKAGE_TOKEN }}
 
     - name: Authenticate gcloud
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.DEV_CP_GCP_SVC_GITHUB_RUNNER_KEY_FILE }}
 
@@ -53,6 +53,9 @@ jobs:
 
         MODIFIED_COINS=$(echo $MODIFIED_COINS | xargs)  # Trim leading/trailing whitespace
         echo "modified_coins=$MODIFIED_COINS" >> $GITHUB_OUTPUT
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
 
     - name: Docker auth
       run: gcloud auth configure-docker ${{ env.REGISTRY }}


### PR DESCRIPTION

add Set up Cloud SDK to fix gcloud command not found error
https://github.com/CoolBitX-Technology/coolwallet-sdk/actions/runs/11284557686/job/31385934383
有試過增加 `Set up Cloud SDK `後，可正常執行 gcloud
https://github.com/CoolBitX-Technology/coolwallet-sdk/actions/runs/11287210006

----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
