### PR TITLE
⬆️ chore(core): update core to 1.1.30 from beta

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.30-beta.1",
+  "version": "1.1.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "1.1.30-beta.1",
+      "version": "1.1.30",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.30-beta.1",
+  "version": "1.1.30",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
`@coolwallet/core` had been used on CoolWallet App production.
 
 **PR Summary by Typo**
------------

 **Summary**

Updated "@coolwallet/core" package version from beta to stable in package-lock.json and package.json.

**Key Points**

* Changed "@coolwallet/core" version from "1.1.30-beta.1" to "1.1.30"
* Updated package-lock.json and package.json accordingly. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>