### PR TITLE
✨ [CW-20101] feat: remove trx usdc from official token

### DIFF
--- a/packages/coin-trx/package-lock.json
+++ b/packages/coin-trx/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/trx",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/trx",
-      "version": "1.1.5",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "14.14.10",

--- a/packages/coin-trx/package.json
+++ b/packages/coin-trx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/trx",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Coolwallet Tron sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-trx/src/config/tokenType.ts
+++ b/packages/coin-trx/src/config/tokenType.ts
@@ -1,14 +1,5 @@
 export const TOKENTYPE = [
   {
-    name: 'USD Coin',
-    symbol: 'USDC',
-    decimals: '6',
-    contractAddress: '3487b63d30b5b2c87fb7ffa8bcfade38eaac1abe',
-    paylaod: '0604555344430000003487b63d30b5b2c87fb7ffa8bcfade38eaac1abe',
-    signature: 
-      '304502200F4013E35088931BCE0EAA281A9B30697E876F678CD36CE4832BDB72F10893380221008F638481A72A6B9E89924879E9E7A626704864B92A62D19EC99E7BD7EA3E5A71'
-  },
-  {
     name: 'Tether USD',
     symbol: 'USDT',
     decimals: '6',


### PR DESCRIPTION
local build 驗證：
1. 確認 App 加幣頁已移除 TRX USDC✅
2. 確認發送 TRX USDC 卡片出現三條線([tx](https://tronscan.org/#/transaction/b714421afb477f027381084a936bd1713e0a2bc807d2b7c3956ab9a9d713e4a2))✅

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

 **Summary:**
Upgrades "@coolwallet/trx" package to version "1.1.7" and removes an outdated token configuration.

**Key Points:**

1. Updates package versions in `package-lock.json` and `package.json`.
2. Removes outdated token configuration from `src/config/tokenType.ts`. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>