### PR TITLE
fix(bch): [CW-22894] cannot send to specfic address that starts with 3

### DIFF
--- a/packages/coin-bch/__tests__/index.spec.ts
+++ b/packages/coin-bch/__tests__/index.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable max-len */
 import { Transport } from '@coolwallet/core';
 import { createTransport } from '@coolwallet/transport-jre-http';
 import { initialize } from '@coolwallet/testing-library';
@@ -13,11 +15,7 @@ describe('Test BCH SDK', () => {
   const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo card';
 
   beforeAll(async () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     transport = (await createTransport())!;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     props = await initialize(transport, mnemonic);
   });
 
@@ -27,61 +25,72 @@ describe('Test BCH SDK', () => {
     expect(address).toMatchInlineSnapshot(`"bitcoincash:qqsykjppczqgptj2pxkyx7vhzldgteer75axzvzqmz"`);
   });
 
-  it('BCH signTransaction 1', async () => {
-    const signTxObject: types.signTxType = {
-      transport,
-      appPrivateKey: props.appPrivateKey,
-      appId: props.appId,
-      scriptType: bch.ScriptType.P2PKH,
-      inputs: [
-        {
-          preTxHash: '1a158298c1c90f3103f4a1ebcff31ec518fcda259f6b3d21fa0ef50b68df31ee',
-          preIndex: 1,
-          preValue: '62500',
-          addressIndex: 1,
-        },
-      ],
-      output: {
-        address: 'qp7qjrz80t4e62hyth4r93l5dtekjn6v95le58eyae',
-        value: '1000',
-      },
-      change: {
-        addressIndex: 1,
-        value: '52500',
-      },
-    };
-    const signedTx = await bch.signTransaction(signTxObject);
-    expect(signedTx).toMatchInlineSnapshot(
-      `"0100000001ee31df680bf50efa213d6b9f25dafc18c51ef3cfeba1f403310fc9c19882151a010000006a47304402207830707295591416088bfeb557ae4cc4d3bdcf2bf5d6899946868fb8be0bcac802200783ea3ff174cf3c65b16a3c3f27d3d35034490cbf067e262aa1290cc7f49c2d41210340b76f102ea4a4fe4456c81087a0a7074ddb726af74e89808fbadda42538ae9cffffffff02e8030000000000001976a9147c090c477aeb9d2ae45dea32c7f46af3694f4c2d88ac14cd0000000000001976a914c6743db99915013c6a230f502e4dc70f0aa2833388ac00000000"`
-    );
-  });
-
-  it('BCH signTransaction 2', async () => {
-    const signTxObject: types.signTxType = {
-      transport,
-      appPrivateKey: props.appPrivateKey,
-      appId: props.appId,
-      scriptType: bch.ScriptType.P2PKH,
-      inputs: [
-        {
-          preTxHash: '263048a31bd12b9324cc35920719ebd47f7fbc802f54d940b873b9cb3ec1c106',
-          preIndex: 1,
-          preValue: '21325',
-          addressIndex: 0,
-        },
-      ],
-      output: {
-        address: '3H62dZMmocjZub6y2r18vgrem3EKsELg2p',
-        value: '1000',
-      },
-      change: {
+  describe('BCH signTransaction', () => {
+    const inputs = [
+      {
+        preTxHash: 'a8e10cdf0dada34b1c22ef976299331701ce9a55c3ee114deee259f76bd1fa7f',
+        preIndex: 0,
+        preValue: '9013114',
         addressIndex: 0,
-        value: '11325',
       },
+    ];
+
+    const output = {
+      address: '12XsqVooX3c3TUUfSBFLqaxtGxELHnumb7',
+      value: '1000000',
     };
-    const signedTx = await bch.signTransaction(signTxObject);
-    expect(signedTx).toMatchInlineSnapshot(
-      `"010000000106c1c13ecbb973b840d9542f80bc7f7fd4eb19079235cc24932bd11ba3483026010000006a47304402207f20adf54c53136222d6264739a014f8ac5e8d68e2a19f6a771f9225d213a45e02207e323670d5e2ca03721f07eb471ff70e922441feabe2a731f345cb825432c11b4121037bae8ad5dd171efdc3a911cebd3d31cd2ffb0892cd63dc6eb00ec716ca446504ffffffff02e80300000000000017a914a8e40b4f6cd04ef541888ea2c047e3d8a38ef379873d2c0000000000001976a914204b4821c08080ae4a09ac43799717da85e723f588ac00000000"`
-    );
+
+    const change = {
+      addressIndex: 0,
+      value: '8004114',
+    };
+
+    it('to address starts with 1', async () => {
+      const signTxObject: types.signTxType = {
+        transport,
+        appPrivateKey: props.appPrivateKey,
+        appId: props.appId,
+        scriptType: bch.ScriptType.P2PKH,
+        inputs,
+        output,
+        change,
+      };
+      const signedTx = await bch.signTransaction(signTxObject);
+      expect(signedTx).toMatchInlineSnapshot(
+        `"01000000017ffad16bf759e2ee4d11eec3559ace011733996297ef221c4ba3ad0ddf0ce1a8000000006b483045022100c80a57a37578b623a787cd55dfe0a6887a7be96faef9fb965a9e433d1599937e0220517cef97b34d72ad039037b790c551e899cd3cb6ad03282443ef0a0b3914da0b4121037bae8ad5dd171efdc3a911cebd3d31cd2ffb0892cd63dc6eb00ec716ca446504ffffffff0240420f00000000001976a91410cf0a5f63558110de85bfb26fa94e4740c5238b88ac12227a00000000001976a914204b4821c08080ae4a09ac43799717da85e723f588ac00000000"`
+      );
+    });
+
+    it('to address starts with 3', async () => {
+      const signTxObject: types.signTxType = {
+        transport,
+        appPrivateKey: props.appPrivateKey,
+        appId: props.appId,
+        scriptType: bch.ScriptType.P2PKH,
+        inputs,
+        output: { ...output, address: '3H62dZMmocjZub6y2r18vgrem3EKsELg2p' },
+        change,
+      };
+      const signedTx = await bch.signTransaction(signTxObject);
+      expect(signedTx).toMatchInlineSnapshot(
+        `"01000000017ffad16bf759e2ee4d11eec3559ace011733996297ef221c4ba3ad0ddf0ce1a8000000006a47304402203919719b9667d743fb17bf666526712b888aeb21ce5ada47ee6d4bb6f62521a3022008df62938384ddff07ccbbd73a4b54aec22589609a011ec6cf0a1a4a845026014121037bae8ad5dd171efdc3a911cebd3d31cd2ffb0892cd63dc6eb00ec716ca446504ffffffff0240420f000000000017a914a8e40b4f6cd04ef541888ea2c047e3d8a38ef3798712227a00000000001976a914204b4821c08080ae4a09ac43799717da85e723f588ac00000000"`
+      );
+    });
+
+    it('to address starts with 3 and no changes', async () => {
+      const signTxObject: types.signTxType = {
+        transport,
+        appPrivateKey: props.appPrivateKey,
+        appId: props.appId,
+        scriptType: bch.ScriptType.P2PKH,
+        inputs,
+        output: { ...output, address: '3H62dZMmocjZub6y2r18vgrem3EKsELg2p' },
+        change: undefined,
+      };
+      const signedTx = await bch.signTransaction(signTxObject);
+      expect(signedTx).toMatchInlineSnapshot(
+        `"01000000017ffad16bf759e2ee4d11eec3559ace011733996297ef221c4ba3ad0ddf0ce1a8000000006a4730440220692e371bd512c45cf5c1ef7408554be03819cf1465d74a0a5c9dc238c780d0fe0220772579b7191c89260d30c9cfe93ec53ac0d75c1b83f4692ab714a29a91183a224121037bae8ad5dd171efdc3a911cebd3d31cd2ffb0892cd63dc6eb00ec716ca446504ffffffff0140420f000000000017a914a8e40b4f6cd04ef541888ea2c047e3d8a38ef3798700000000"`
+      );
+    });
   });
 });

--- a/packages/coin-bch/__tests__/index.spec.ts
+++ b/packages/coin-bch/__tests__/index.spec.ts
@@ -1,0 +1,34 @@
+import { Transport } from '@coolwallet/core';
+import { createTransport } from '@coolwallet/transport-jre-http';
+import { initialize, } from '@coolwallet/testing-library';
+import BCH from '../../coin-bch/src';
+
+type PromiseValue<T> = T extends Promise<infer P> ? P : never;
+
+describe('Test BCH SDK', () => {
+  let props: PromiseValue<ReturnType<typeof initialize>>;
+  let transport: Transport;
+  const bch = new BCH();
+  const mnemonic = 'zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo card';
+
+  beforeAll(async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    transport = (await createTransport())!;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    props = await initialize(transport, mnemonic);
+  });
+
+  it('BCH test get address 0', async () => {
+    const addressIndex = 0;
+    const address = await bch.getAddress(transport, props.appPrivateKey, props.appId, addressIndex);
+    expect(address).toMatchInlineSnapshot(`"bitcoincash:qqsykjppczqgptj2pxkyx7vhzldgteer75axzvzqmz"`);
+  });
+
+  // it.skip('BCH signTransaction 1', async () => {
+  // });
+
+  // it.skip('BCH signTransaction 2', async () => {
+  // });
+});

--- a/packages/coin-bch/__tests__/index.spec.ts
+++ b/packages/coin-bch/__tests__/index.spec.ts
@@ -1,7 +1,8 @@
 import { Transport } from '@coolwallet/core';
 import { createTransport } from '@coolwallet/transport-jre-http';
-import { initialize, } from '@coolwallet/testing-library';
+import { initialize } from '@coolwallet/testing-library';
 import BCH from '../../coin-bch/src';
+import * as types from '../src/config/types';
 
 type PromiseValue<T> = T extends Promise<infer P> ? P : never;
 
@@ -26,9 +27,61 @@ describe('Test BCH SDK', () => {
     expect(address).toMatchInlineSnapshot(`"bitcoincash:qqsykjppczqgptj2pxkyx7vhzldgteer75axzvzqmz"`);
   });
 
-  // it.skip('BCH signTransaction 1', async () => {
-  // });
+  it('BCH signTransaction 1', async () => {
+    const signTxObject: types.signTxType = {
+      transport,
+      appPrivateKey: props.appPrivateKey,
+      appId: props.appId,
+      scriptType: bch.ScriptType.P2PKH,
+      inputs: [
+        {
+          preTxHash: '1a158298c1c90f3103f4a1ebcff31ec518fcda259f6b3d21fa0ef50b68df31ee',
+          preIndex: 1,
+          preValue: '62500',
+          addressIndex: 1,
+        },
+      ],
+      output: {
+        address: 'qp7qjrz80t4e62hyth4r93l5dtekjn6v95le58eyae',
+        value: '1000',
+      },
+      change: {
+        addressIndex: 1,
+        value: '52500',
+      },
+    };
+    const signedTx = await bch.signTransaction(signTxObject);
+    expect(signedTx).toMatchInlineSnapshot(
+      `"0100000001ee31df680bf50efa213d6b9f25dafc18c51ef3cfeba1f403310fc9c19882151a010000006a47304402207830707295591416088bfeb557ae4cc4d3bdcf2bf5d6899946868fb8be0bcac802200783ea3ff174cf3c65b16a3c3f27d3d35034490cbf067e262aa1290cc7f49c2d41210340b76f102ea4a4fe4456c81087a0a7074ddb726af74e89808fbadda42538ae9cffffffff02e8030000000000001976a9147c090c477aeb9d2ae45dea32c7f46af3694f4c2d88ac14cd0000000000001976a914c6743db99915013c6a230f502e4dc70f0aa2833388ac00000000"`
+    );
+  });
 
-  // it.skip('BCH signTransaction 2', async () => {
-  // });
+  it('BCH signTransaction 2', async () => {
+    const signTxObject: types.signTxType = {
+      transport,
+      appPrivateKey: props.appPrivateKey,
+      appId: props.appId,
+      scriptType: bch.ScriptType.P2PKH,
+      inputs: [
+        {
+          preTxHash: '263048a31bd12b9324cc35920719ebd47f7fbc802f54d940b873b9cb3ec1c106',
+          preIndex: 1,
+          preValue: '21325',
+          addressIndex: 0,
+        },
+      ],
+      output: {
+        address: '3H62dZMmocjZub6y2r18vgrem3EKsELg2p',
+        value: '1000',
+      },
+      change: {
+        addressIndex: 0,
+        value: '11325',
+      },
+    };
+    const signedTx = await bch.signTransaction(signTxObject);
+    expect(signedTx).toMatchInlineSnapshot(
+      `"010000000106c1c13ecbb973b840d9542f80bc7f7fd4eb19079235cc24932bd11ba3483026010000006a47304402207f20adf54c53136222d6264739a014f8ac5e8d68e2a19f6a771f9225d213a45e02207e323670d5e2ca03721f07eb471ff70e922441feabe2a731f345cb825432c11b4121037bae8ad5dd171efdc3a911cebd3d31cd2ffb0892cd63dc6eb00ec716ca446504ffffffff02e80300000000000017a914a8e40b4f6cd04ef541888ea2c047e3d8a38ef379873d2c0000000000001976a914204b4821c08080ae4a09ac43799717da85e723f588ac00000000"`
+    );
+  });
 });

--- a/packages/coin-bch/package-lock.json
+++ b/packages/coin-bch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/bch",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/bch",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "ISC",
       "dependencies": {
         "@types/bn.js": "^4.11.6",

--- a/packages/coin-bch/package.json
+++ b/packages/coin-bch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/bch",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Coolwallet Bitcoin Cash sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-bch/package.json
+++ b/packages/coin-bch/package.json
@@ -4,7 +4,7 @@
   "description": "Coolwallet Bitcoin Cash sdk",
   "main": "lib/index.js",
   "scripts": {
-    "test": "NODE_ENV=development jest",
+    "test": "NODE_ENV=development jest --runInBand",
     "ci-test": "NODE_ENV=production jest --runInBand",
     "ci-test-report": "NODE_ENV=production jest --no-bail --runInBand --reporters=default --reporters=jest-junit --testResultsProcessor=jest-junit",
     "build:types": "tsc --emitDeclarationOnly",

--- a/packages/coin-bch/package.json
+++ b/packages/coin-bch/package.json
@@ -4,6 +4,9 @@
   "description": "Coolwallet Bitcoin Cash sdk",
   "main": "lib/index.js",
   "scripts": {
+    "test": "NODE_ENV=development jest",
+    "ci-test": "NODE_ENV=production jest --runInBand",
+    "ci-test-report": "NODE_ENV=production jest --no-bail --runInBand --reporters=default --reporters=jest-junit --testResultsProcessor=jest-junit",
     "build:types": "tsc --emitDeclarationOnly",
     "build:ts": "babel src --out-dir lib --extensions \".ts,.tsx\" --source-maps inline",
     "build": "npm run build:types && npm run build:ts",
@@ -50,5 +53,12 @@
   },
   "bugs": {
     "url": "https://github.com/CoolBitX-Technology/coolwallet3-sdk/issues"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "../../jest.setup.js"
+    ],
+    "testTimeout": 60000,
+    "collectCoverage": true
   }
 }

--- a/packages/coin-bch/src/index.ts
+++ b/packages/coin-bch/src/index.ts
@@ -5,7 +5,7 @@ import * as params from './config/params';
 import * as txUtil from './utils/transactionUtil';
 
 export default class BCH extends COIN.ECDSACoin implements COIN.Coin {
-  public ScriptType: any;
+  public ScriptType: typeof types.ScriptType;
   public addressToOutScript: (address: string) => {
     scriptType: types.ScriptType;
     outScript: Buffer;

--- a/packages/coin-bch/src/utils/scriptUtil.ts
+++ b/packages/coin-bch/src/utils/scriptUtil.ts
@@ -6,6 +6,7 @@ import * as types from '../config/types';
 import * as params from '../config/params';
 
 export async function getArgument(
+  scriptType: types.ScriptType,
   inputs: Array<types.Input>,
   output: types.Output,
   change?: types.Change,
@@ -33,7 +34,7 @@ export async function getArgument(
       throw new Error('Public Key not exists !!');
     }
     haveChange = bufferUtil.toVarUintBuffer(1);
-    changeScriptType = bufferUtil.toVarUintBuffer(outputType);
+    changeScriptType = bufferUtil.toVarUintBuffer(scriptType);
     changeAmount = bufferUtil.toUintBuffer(change.value, 8);
     // const addressIdHex = "00".concat(change.addressIndex.toString(16).padStart(6, "0"));
     changePath = Buffer.from(await utils.getPath(params.COIN_TYPE, change.addressIndex), 'hex');
@@ -82,7 +83,7 @@ export async function getScriptSigningActions(
   actions: Array<Function>
 }> {
   const script = params.TRANSFER.script + params.TRANSFER.signature;
-  const argument = "00" + await getArgument(inputs, output, change);// keylength zero
+  const argument = "00" + await getArgument(scriptType, inputs, output, change);// keylength zero
 
   const preActions = [];
   const sendScript = async () => {

--- a/packages/coin-bch/tsconfig.json
+++ b/packages/coin-bch/tsconfig.json
@@ -10,6 +10,6 @@
     "strict": true,                           /* Enable all strict type-checking options. */
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    
-  }
+  },
+  "include": ["src/**/*"]
 }

--- a/scripts/run-all-test-report.sh
+++ b/scripts/run-all-test-report.sh
@@ -2,6 +2,7 @@ TEST_FIXTURE_SCOPES="--scope @coolwallet/core --scope @coolwallet/testing-librar
 TEST_SCOPES=(
   --scope @coolwallet/core
   --scope @coolwallet/btc
+  --scope @coolwallet/bch
   --scope @coolwallet/dot
   --scope @coolwallet/kas
   --scope @coolwallet/ton


### PR DESCRIPTION
- **test: add test case - `BCH test get address 0`**
- **test: add BCH signTransaction test case**
- **feat: add ScriptType type**

 
 
 
 
 
 **PR Summary by Typo**
------------

 **Summary:**
This pull request introduces new tests for the BCH SDK and updates the Jest configuration in the `coin-bch` package.

**Key Points:**

1. Adds tests for getting an address and signing a transaction in `index.spec.ts`.
2. Introduces two new tests for the `signTransaction` function in the Bitcoin Cash library.
3. Updates Jest configuration with new options in `package.json`.
4. Changes `ScriptType` definition in `BCH` class and updates `tsconfig.json`.
5. Adds new test scope "@coolwallet/bch" to the existing list in the "run-all-test-report.sh" script. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>