### PR TITLE
fix(core): correct bip66.encode type to Buffer

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/bip66.d.ts
+++ b/packages/core/src/bip66.d.ts
@@ -1,4 +1,4 @@
 declare module 'bip66' {
   function decode(signature: Buffer): { r: Buffer; s: Buffer };
-  function encode(r: Buffer, s: Buffer): any;
+  function encode(r: Buffer, s: Buffer): Buffer;
 }

--- a/packages/core/src/crypto/signature.ts
+++ b/packages/core/src/crypto/signature.ts
@@ -18,7 +18,7 @@ export const parseDERsignature = (signature: string) => {
  * @param {{r:string, s:string}}
  * @return {Buffer}
  */
-export const convertToDER = (sig: { r: string; s: string }): { r: string; s: string } => {
+export const convertToDER = (sig: { r: string; s: string }): Buffer => {
   let canRBuffer = Buffer.from(sig.r, 'hex');
   let canSBuffer = Buffer.from(sig.s, 'hex');
 


### PR DESCRIPTION
correct bip66.encode type from any to Buffer
 
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates package versions and modifies a function return type.

* Updates "@coolwallet/core" version in package-lock.json and package.json
* Changes "convertToDER" function return type in signature.ts from object to Buffer. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>