### PR TITLE
chore: remove OTA api secret

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+
+## 1.2.0-beta.0
+
+### Breaking
+
+- [`updateSE`](./src/apdu/ota/ota.ts#updateSE) function parameters type has been modified (#924)
+
+### Changed
+
+- remove OTA api secret (#924)

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.31",
+  "version": "1.2.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "1.1.31",
+      "version": "1.2.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "1.1.31",
+  "version": "1.2.0-beta.0",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/apdu/index.ts
+++ b/packages/core/src/apdu/index.ts
@@ -8,6 +8,4 @@ import * as tx from './transaction';
 import * as pair from './pair';
 import * as ota from './ota';
 
-export {
-	mcu, setting, info, execute, general, wallet, pair, tx, ota
-};
+export { mcu, setting, info, execute, general, wallet, pair, tx, ota };

--- a/packages/core/src/apdu/ota/api.ts
+++ b/packages/core/src/apdu/ota/api.ts
@@ -8,12 +8,21 @@ import jwt from '../../utils/jwt';
 
 import type { APIOptions, Command } from './types';
 
+interface APIOptionInput {
+  cardId: string;
+  challengeData?: string;
+  apiSecret: string;
+}
+
 /**
  *
  * @param data
  */
-const getAPIOption = async (cardId: string, challengeData = ''): Promise<APIOptions> => {
-  const secret = 'd579bf4a2883cecf610785c49623e1';
+const getAPIOption = async ({ cardId, challengeData = '', apiSecret }: APIOptionInput): Promise<APIOptions> => {
+  const secret = apiSecret;
+  if (!secret) {
+    throw new SDKError(getAPIOption.name, 'API Secret is required');
+  }
   // let payload = new TokenSigner('ES256K', secret).sign(data)
   // console.log(`signed token ${payload}`)
 

--- a/packages/core/src/apdu/ota/index.ts
+++ b/packages/core/src/apdu/ota/index.ts
@@ -1,2 +1,1 @@
 export { selectApplet, updateSE, checkUpdate } from './ota';
-export { formatAPIResponse, getAPIOption } from './api';

--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -65,7 +65,8 @@ export const updateSE = async (
   appPrivateKey: string,
   progressCallback: (progress: number) => void,
   callAPI: (url: string, options: APIOptions) => Promise<any>,
-  updateMCU = false
+  updateMCU = false,
+  apiSecret: string
 ): Promise<number> => {
   // BackupApplet
   let cardSEVersion;
@@ -122,11 +123,11 @@ export const updateSE = async (
     progressCallback(progress.next()); // progress 36
 
     console.debug('mutual Authorization Start----');
-    const options = await getAPIOption(cardId);
+    const options = await getAPIOption({ cardId, apiSecret });
     const challengeResponse = await callAPI(CHALLENGE_URL, options);
     console.debug('cardID: ', cardId);
     const challengeObj = await formatAPIResponse(transport, challengeResponse);
-    const challengeOptions = await getAPIOption(cardId, challengeObj.outputData);
+    const challengeOptions = await getAPIOption({ cardId, challengeData: challengeObj.outputData, apiSecret });
     const cryptogramResponse = await callAPI(CRYPTOGRAM_URL, challengeOptions);
     await formatAPIResponse(transport, cryptogramResponse);
     console.debug('mutual Authorization Done----');

--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -48,6 +48,17 @@ export const checkUpdate = async (transport: Transport): Promise<SEUpdateInfo> =
   return { isNeedUpdate, curVersion: cardSEVersion, newVersion: SE_UPDATE_VER };
 };
 
+interface UpdateSeParams {
+  transport: Transport;
+  cardId: string;
+  appId: string;
+  appPrivateKey: string;
+  progressCallback: (progress: number) => void;
+  callAPI: (url: string, options: APIOptions) => Promise<any>;
+  updateMCU?: boolean;
+  apiSecret: string;
+}
+
 /**
  *
  * @param transport
@@ -58,16 +69,16 @@ export const checkUpdate = async (transport: Transport): Promise<SEUpdateInfo> =
  * @param callAPI callAPI(url, options): Function of calling api
  * @param updateMCU
  */
-export const updateSE = async (
-  transport: Transport,
-  cardId: string,
-  appId: string,
-  appPrivateKey: string,
-  progressCallback: (progress: number) => void,
-  callAPI: (url: string, options: APIOptions) => Promise<any>,
+export const updateSE = async ({
+  transport,
+  cardId,
+  appId,
+  appPrivateKey,
+  progressCallback,
+  callAPI,
   updateMCU = false,
-  apiSecret: string
-): Promise<number> => {
+  apiSecret,
+}: UpdateSeParams): Promise<number> => {
   // BackupApplet
   let cardSEVersion;
   try {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
This pull request introduces version 1.2.0-beta.0 of @coolwallet/core with a breaking change in `updateSE` function's parameter and removal of the OTA api secret. It also refactors `updateSE` and introduces a new interface `UpdateSeParams`.

**Key Points:**

1. Introduces new version with breaking change and dependency updates.
2. Refactors `updateSE` function with new interface and optional `apiSecret` parameter.
3. Updates `getAPIOption` function to accept optional `apiSecret` parameter. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>