### PR TITLE
✨ feat(atom): export types from index so that client can import type from index

### DIFF
--- a/packages/coin-atom/package-lock.json
+++ b/packages/coin-atom/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/atom",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/atom",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "ISC",
       "dependencies": {
         "bech32": "^1.1.3",

--- a/packages/coin-atom/package.json
+++ b/packages/coin-atom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/atom",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Cosmos API for CoolWalletS",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-atom/src/config/types.ts
+++ b/packages/coin-atom/src/config/types.ts
@@ -54,6 +54,7 @@ export interface MsgDelegate extends Cosmos {
   amount: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MsgUndelegate extends MsgDelegate {}
 
 export interface MsgWithdrawDelegationReward extends Cosmos {

--- a/packages/coin-atom/src/index.ts
+++ b/packages/coin-atom/src/index.ts
@@ -6,7 +6,9 @@ import * as params from './config/params';
 import * as sign from './sign';
 import { SDKError } from '@coolwallet/core/lib/error';
 
-export { TX_TYPE } from './config/types';
+import { MsgWithdrawDelegationReward, MsgUndelegate, MsgDelegate, MsgSend, CHAIN_ID, TX_TYPE } from './config/types';
+
+export { Transport, MsgWithdrawDelegationReward, MsgUndelegate, MsgDelegate, MsgSend, CHAIN_ID, TX_TYPE };
 
 export default class ATOM extends COIN.ECDSACoin implements COIN.Coin {
   public Types: any;


### PR DESCRIPTION
I've tested locally that types can import from index
 
 **PR Summary by Typo**
------------

 **Summary:**
This pull request updates package versions and introduces new interfaces.

**Key Points:**
- Upgrades packages to versions `1.1.4`.
- Introduces `MsgUndelegate` and `MsgWithdrawDelegationReward` interfaces.
- Exports new interfaces, along with other types and classes. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>