### PR TITLE
fix(xrp): wrong version publish

### DIFF
--- a/packages/coin-xrp/package-lock.json
+++ b/packages/coin-xrp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/xrp",
-  "version": "^2.0.0-beta.0",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/xrp",
-      "version": "^2.0.0-beta.0",
+      "version": "2.0.0-beta.0",
       "license": "ISC",
       "dependencies": {
         "@coolwallet/core": "^2.0.0-beta.18",

--- a/packages/coin-xrp/package.json
+++ b/packages/coin-xrp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/xrp",
-  "version": "^2.0.0-beta.0",
+  "version": "2.0.0-beta.0",
   "description": "Coolwallet Ripple App",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR corrects an issue with the XRP package version in `package.json` and `package-lock.json`. The incorrect caret (`^`) was causing an unintended version mismatch during publishing.

**Key Changes**
- Removed the caret (`^`) from the version string in both `package.json` and `package-lock.json`, fixing the version to `2.0.0-beta.0`.

**Recommendations**
Ready to merge. This is a small but important fix to ensure the correct XRP package version is published.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>