### PR TITLE
fix(xrp): 修正因為跑到測試導致部署失敗問題

### DIFF
--- a/packages/coin-xrp/tests/index.spec.ts
+++ b/packages/coin-xrp/tests/index.spec.ts
@@ -1,7 +1,7 @@
 import { CardType, Transport } from '@coolwallet/core';
 import { createTransport } from '@coolwallet/transport-jre-http';
 import { initialize } from '@coolwallet/testing-library';
-import XRP from '../index';
+import XRP from '../src/index';
 
 type PromiseValue<T> = T extends Promise<infer V> ? V : never;
 type Mandatory = PromiseValue<ReturnType<typeof initialize>>;


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR fixes a deployment failure issue in the `coin-xrp` package caused by incorrect import paths during testing.

**Key Changes**
- Corrected the import path of the `XRP` module in the `index.spec.ts` test file from `../index` to `../src/index`.  This change ensures the correct module is used during testing and deployment.

**Recommendations**
Ready to merge after verifying that the unit tests pass and the deployment process completes successfully.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>