### PR TITLE
[CW-21906] feat(kas): support on lite

### DIFF
--- a/packages/coin-kas/package-lock.json
+++ b/packages/coin-kas/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@coolwallet/kas",
-  "version": "1.0.4",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/kas",
-      "version": "1.0.4",
+      "version": "2.0.0-beta.0",
       "license": "ISC",
       "dependencies": {
         "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
-        "@coolwallet/core": "^2.0.0-beta.18",
+        "@coolwallet/core": "2.0.0-beta.19",
         "@types/bn.js": "^5.1.1",
         "bignumber.js": "^8.0.2",
         "bitcoinjs-lib": "^6.1.5",
@@ -1685,9 +1685,9 @@
       }
     },
     "node_modules/@coolwallet/core": {
-      "version": "2.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0-beta.18.tgz",
-      "integrity": "sha512-MDaUnQXLCoTHZuQN/ubLqMm5Gj4viK0JantJyO2Zy8xXFwmju6xU9TfyPyv7x1iRmLQue/giIHvMqpK4U8Jjmg==",
+      "version": "2.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0-beta.19.tgz",
+      "integrity": "sha512-kbKtIqaJbhGGM9TV63VgL0aTKIrf2pV0m8qdUu+gueCa4LZIt6sEFdfcJM0i+q88WIFypGMW8O3At/z4jlFVeQ==",
       "dependencies": {
         "@types/elliptic": "^6.4.14",
         "@types/lodash": "^4.14.177",

--- a/packages/coin-kas/package.json
+++ b/packages/coin-kas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/kas",
-  "version": "1.0.4",
+  "version": "2.0.0-beta.0",
   "description": "Coolwallet Kaspa sdk",
   "main": "lib/index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.3",
-    "@coolwallet/core": "^2.0.0-beta.18",
+    "@coolwallet/core": "2.0.0-beta.19",
     "@types/bn.js": "^5.1.1",
     "bignumber.js": "^8.0.2",
     "bitcoinjs-lib": "^6.1.5",

--- a/packages/coin-kas/src/index.ts
+++ b/packages/coin-kas/src/index.ts
@@ -7,13 +7,15 @@ import {
   getPubkeyOrScriptHash,
 } from './utils/address';
 import signTransferTransaction from './sign';
-import { Payment, Script, ScriptType, SignTxType } from './config/types';
+import * as types from './config/types';
 
 export default class KAS extends COIN.ECDSACoin implements COIN.Coin {
-  public addressToOutScript: (address: string) => Script;
+  public ScriptType: any;
+  public addressToOutScript: (address: string) => types.Script;
 
   constructor() {
     super(COIN_TYPE);
+    this.ScriptType = types.ScriptType;
     this.addressToOutScript = addressToOutScript;
   }
 
@@ -21,7 +23,7 @@ export default class KAS extends COIN.ECDSACoin implements COIN.Coin {
     transport: Transport,
     appPrivateKey: string,
     appId: string,
-    scriptType: ScriptType,
+    scriptType: types.ScriptType,
     addressIndex: number,
     purpose?: number
   ): Promise<string> {
@@ -34,10 +36,10 @@ export default class KAS extends COIN.ECDSACoin implements COIN.Coin {
     transport: Transport,
     appPrivateKey: string,
     appId: string,
-    scriptType: ScriptType,
+    scriptType: types.ScriptType,
     addressIndex: number,
     purpose?: number
-  ): Promise<Payment> {
+  ): Promise<types.Payment> {
     const publicKey = await this.getPublicKey(transport, appPrivateKey, appId, addressIndex, purpose);
     const { pubkeyOrScriptHash, addressVersion } = getPubkeyOrScriptHash(scriptType, publicKey);
     return pubkeyOrScriptHashToPayment(pubkeyOrScriptHash, addressVersion);
@@ -47,14 +49,14 @@ export default class KAS extends COIN.ECDSACoin implements COIN.Coin {
     accPublicKey: string,
     accChainCode: string,
     addressIndex: number,
-    scriptType: ScriptType
-  ): Promise<Payment> {
+    scriptType: types.ScriptType
+  ): Promise<types.Payment> {
     const publicKey = this.getAddressPublicKey(accPublicKey, accChainCode, addressIndex);
     const { pubkeyOrScriptHash, addressVersion } = getPubkeyOrScriptHash(scriptType, publicKey);
     return pubkeyOrScriptHashToPayment(pubkeyOrScriptHash, addressVersion);
   }
 
-  async signTransaction(signTxType: SignTxType): Promise<string> {
+  async signTransaction(signTxType: types.SignTxType): Promise<string> {
     const { inputs, transport, appPrivateKey, appId, change, scriptType } = signTxType;
     for (const input of inputs) {
       const pubkey = await this.getPublicKey(transport, appPrivateKey, appId, input.addressIndex, input.purposeIndex);

--- a/packages/coin-kas/src/sign.ts
+++ b/packages/coin-kas/src/sign.ts
@@ -40,9 +40,9 @@ export default async function signTransferTransaction(signTxData: SignTxType): P
     transport,
     preActions,
     actions,
+    SignatureType.Schnorr,
     confirmCB,
     authorizedCB,
-    SignatureType.Schnorr
   )) as Array<Buffer>;
 
   transaction.addSignatures(signatures);

--- a/packages/coin-kas/src/utils/scriptUtil.ts
+++ b/packages/coin-kas/src/utils/scriptUtil.ts
@@ -1,4 +1,4 @@
-import { apdu, Transport, utils } from '@coolwallet/core';
+import { tx, Transport, utils } from '@coolwallet/core';
 import { PathType } from '@coolwallet/core/lib/config';
 import { Transaction } from '../transaction';
 import { getUtxoArgumentBuffer } from './hash';
@@ -25,12 +25,12 @@ export function getSigningPreActions(
 
   const preActions = [];
   const sendScript = async () => {
-    await apdu.tx.sendScript(transport, script);
+    await tx.command.sendScript(transport, script);
   };
   preActions.push(sendScript);
 
   const sendArgument = async () => {
-    await apdu.tx.executeScript(transport, appId, appPrivateKey, argument);
+    await tx.command.executeScript(transport, appId, appPrivateKey, argument);
   };
   preActions.push(sendArgument);
 
@@ -51,7 +51,7 @@ export async function getSigningActions(
     return utxoArgumentBuf.toString('hex');
   });
   const actions = utxoArguments.map((utxoArgument) => async () => {
-    return apdu.tx.executeUtxoSegmentScript(
+    return tx.command.executeUtxoSegmentScript(
       transport,
       appId,
       appPrivateKey,


### PR DESCRIPTION
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR updates the `@coolwallet/kas` package to support CoolWallet Lite. It bumps the package version to `2.0.0-beta.0` and updates the `@coolwallet/core` dependency to `2.0.0-beta.19`.  The PR also modifies the transaction signing process and exports `ScriptType`.

**Key Changes**
- Updated `@coolwallet/core` dependency to `2.0.0-beta.19`.
- Changed `apdu.tx.*` calls to `tx.command.*` for CoolWallet Lite compatibility.
- Exported `ScriptType` for external use.
- Modified type imports and usage to avoid potential conflicts.
- Updated package version to `2.0.0-beta.0`.

**Recommendations**
Ready for merge after testing the KAS SDK with CoolWallet Lite to ensure all functionalities work as expected, especially the transaction signing process. Verify the updated types and exported `ScriptType` don't introduce any breaking changes for existing users.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>