### PR TITLE
feat(core): support creating cardano seed on coolwallet go

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.0-beta.19",
+  "version": "2.0.0-beta.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.0-beta.19",
+      "version": "2.0.0-beta.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.0-beta.19",
+  "version": "2.0.0-beta.20",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,7 +1,7 @@
 import * as bip39 from 'bip39';
 import pbkdf2 from 'pbkdf2';
 import isEmpty from 'lodash/isEmpty';
-import Transport from '../transport';
+import Transport, { CardType } from '../transport';
 import { MSG } from '../config/status/msg';
 import { CODE } from '../config/status/code';
 import { PathType } from '../config/param';
@@ -198,7 +198,7 @@ export const createWalletByMnemonic = async (
 
   // mnemonic to ADA master key
   const version = await info.getSEVersion(transport);
-  if (version >= 317) {
+  if ((transport.cardType === CardType.Pro && version >= 317) || transport.cardType === CardType.Lite) {
     seeds[1] = createAdaMasterKeyByMnemonic(mnemonic);
   }
 


### PR DESCRIPTION
----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

**Overview**
This PR adds support for creating Cardano seeds on CoolWallet Go devices.  The core library version is bumped to 2.0.0-beta.20.

**Key Changes**
- Updated the `createWalletByMnemonic` function to conditionally create Cardano master keys based on the CoolWallet version and type (Pro or Lite).  CoolWallet Pro requires version 317 or higher.
- Updated package version to 2.0.0-beta.20.

**Recommendations**
Not deployment ready.  While the changes seem targeted, more information is needed to assess production readiness. Please provide details on testing performed, especially integration tests with CoolWallet Go devices, to confirm the functionality.  Additionally, clarify the backward compatibility impact of this change.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>