### PR TITLE
feat(zen): export script type from zen

### DIFF
--- a/packages/coin-zen/package-lock.json
+++ b/packages/coin-zen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/zen",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/zen",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@coolwallet/core": "2.0.0-beta.20",

--- a/packages/coin-zen/package.json
+++ b/packages/coin-zen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/zen",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Coolwallet Horizen sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-zen/src/index.ts
+++ b/packages/coin-zen/src/index.ts
@@ -3,7 +3,10 @@ import { signTransaction } from './sign';
 import * as types from './config/types';
 import * as params from './config/params';
 import * as txUtil from './utils/transactionUtil';
-export default class BTC extends COIN.ECDSACoin implements COIN.Coin {
+
+export type ScriptType = types.ScriptType;
+
+export default class ZEN extends COIN.ECDSACoin implements COIN.Coin {
   public addressToOutScript: (address: string) => { scriptType: types.ScriptType; outScript: Buffer; outHash?: Buffer };
 
   constructor() {

--- a/packages/coin-zen/src/index.ts
+++ b/packages/coin-zen/src/index.ts
@@ -4,7 +4,7 @@ import * as types from './config/types';
 import * as params from './config/params';
 import * as txUtil from './utils/transactionUtil';
 
-export type ScriptType = types.ScriptType;
+export const ScriptType = types.ScriptType;
 
 export default class ZEN extends COIN.ECDSACoin implements COIN.Coin {
   public addressToOutScript: (address: string) => { scriptType: types.ScriptType; outScript: Buffer; outHash?: Buffer };
@@ -43,7 +43,16 @@ export default class ZEN extends COIN.ECDSACoin implements COIN.Coin {
     addressIndex: number,
     scriptType: types.ScriptType
   ): Promise<{ address: string; outScript: Buffer }> {
-    const publicKey = await this.getAddressPublicKey(accPublicKey, accChainCode, addressIndex);
+    return this.getAddressAndOutScriptByAccountKeySync(accPublicKey, accChainCode, addressIndex, scriptType);
+  }
+
+  getAddressAndOutScriptByAccountKeySync(
+    accPublicKey: string,
+    accChainCode: string,
+    addressIndex: number,
+    scriptType: types.ScriptType
+  ): { address: string; outScript: Buffer } {
+    const publicKey = this.getAddressPublicKey(accPublicKey, accChainCode, addressIndex);
     return txUtil.pubkeyToAddressAndOutScript(Buffer.from(publicKey, 'hex'), scriptType);
   }
 


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR updates the `@coolwallet/zen` package to version 2.0.0-beta.1. It introduces the export of `ScriptType` and renames the default export class from `BTC` to `ZEN`.  It also adds a synchronous method `getAddressAndOutScriptByAccountKeySync`.

**Key Changes**
- Package version bumped to 2.0.0-beta.1.
- `ScriptType` from `./config/types` is now exported.
- Default export class renamed from `BTC` to `ZEN`.
- New synchronous method `getAddressAndOutScriptByAccountKeySync` added.
- Asynchronous `getAddressAndOutScriptByAccountKey` now uses the synchronous method internally.

**Recommendations**
Not deployment ready. While the changes seem minor, the lack of explanation for the renaming and the addition of the synchronous method raises concerns.  Provide more context on the reasons for these changes and add unit tests to cover the new synchronous method and ensure existing functionality isn't affected by the refactoring of the asynchronous method.  Clarify the intended use case for both the synchronous and asynchronous versions of the method.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>