### PR TITLE
feat(Crypto.org): remove getSignedHex

### DIFF
--- a/packages/coin-cro/package-lock.json
+++ b/packages/coin-cro/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/cro",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/cro",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "2.0.0-beta.20",

--- a/packages/coin-cro/package.json
+++ b/packages/coin-cro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/cro",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Coolwallet Crypto.org Chain sdk",
   "main": "lib/index.js",
   "author": "coolwallet-team",

--- a/packages/coin-cro/src/sign.ts
+++ b/packages/coin-cro/src/sign.ts
@@ -28,9 +28,6 @@ export const signTransaction = async (
     authorizedCB
   );
 
-  const { signedTx } = await tx.command.getSignedHex(transport);
-  console.debug('signedTx: ', signedTx);
-
   if (!Buffer.isBuffer(canonicalSignature)) {
     const croSignature = await txUtil.genCROSigFromSESig(canonicalSignature);
     return croSignature;


### PR DESCRIPTION
----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

**Overview**
This PR removes the `getSignedHex` function call and associated logging within the `signTransaction` function in `sign.ts`.  It also bumps the package version from `2.0.0-beta.0` to `2.0.0-beta.1`.

**Key Changes**
- Removed `getSignedHex` function call.
- Removed console logging of `signedTx`.
- Updated package version.

**Recommendations**
Not deployment ready. While the removal of the logging statement is a positive change, the removal of `getSignedHex` without explanation raises concerns.  The PR needs more context explaining why this function is no longer necessary and what impact its removal has on the signing process.  Add unit tests to verify the signing functionality still works as expected after this change.  Clarify the reasoning behind removing `getSignedHex` in the PR description.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>