### PR TITLE
feat(nfc-transport): add APDU request and response logs

### DIFF
--- a/packages/transport-react-native-nfc/package-lock.json
+++ b/packages/transport-react-native-nfc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/transport-react-native-nfc",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "^2.0.0-beta.21",

--- a/packages/transport-react-native-nfc/package.json
+++ b/packages/transport-react-native-nfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/transport-react-native-nfc",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/transport-react-native-nfc/src/transport.ts
+++ b/packages/transport-react-native-nfc/src/transport.ts
@@ -24,6 +24,11 @@ class NFCTransport implements Transport {
   };
 
   request = async (command: string, packets: string): Promise<string> => {
+    const start = Date.now();
+
+    console.log('NFCTransport.request >> command=', command);
+    console.log('NFCTransport.request >> packets=', packets);
+
     if (!command.startsWith(PID + CMD_LEN)) {
       throw new TransportError(this.request.name, 'Unknown command payload.');
     }
@@ -45,7 +50,13 @@ class NFCTransport implements Transport {
       );
 
       const response = await NfcManager.isoDepHandler.transceive(commandBytes);
-      return numberArrayToHexString(response);
+      console.log('NFCTransport.request >> responseBytes length=', response.length);
+      const responseHex = numberArrayToHexString(response);
+      console.log('NFCTransport.request >> responseHex=', responseHex);
+      const end = Date.now();
+      console.log('NFCTransport.request >> time taken=', end - start);
+      return responseHex;
+
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
       const transportError = new TransportError(this.request.name, errorMessage);


### PR DESCRIPTION
- **chore: add nfc transport log**
- **chore(transport-react-native-nfc): bump version to 1.0.0-beta.8**

 
 **PR Summary by Typo**
------------

**Overview:**
This PR adds logging for APDU requests and responses in the `NFCTransport` class within the `transport-react-native-nfc` package. This enhancement aims to improve debugging and monitoring capabilities.  It also increments the package version.

**Key Changes:**
- Added `console.log` statements to display the APDU command, packets, response length, response in hex format, and time taken for each request.
- Incremented package version from `1.0.0-beta.7` to `1.0.0-beta.8`.

**Recommendations:**
Not deployment ready. While the added logging is helpful for debugging, consider using a dedicated logging library instead of `console.log` for production environments. This allows for more control over log levels, formatting, and output destinations.  Also, ensure the logging doesn't expose sensitive data.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>