### PR TITLE
chore: CW-24146 do backup register data event if card is not recognized

### DIFF
--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -85,14 +85,28 @@ const performBackupRegisterData = async (transport: Transport, appId: string, ap
   const isAppletExist = await safeCheckMainAppletExists(transport);
   if (!isAppletExist) return; // no need to do backup because no main applet.
 
-  const isCardRecognized = await common.hi(transport, appId);
-  if (!isCardRecognized) return; // don't do backup becuase card cannot recognize device(appId).
+  // const isCardRecognized = await common.hi(transport, appId);
+  // if (!isCardRecognized) return; // don't do backup becuase card cannot recognize device(appId).
 
-  const { walletCreated } = await info.getCardInfo(transport);
-  console.debug(`isCardRecognized: ${isCardRecognized}, walletStatus: ${walletCreated}`);
+  try {
+    console.debug('performBackupRegisterData >> deleteBackupRegisterData try');
+    await deleteBackupRegisterData(transport, appId, appPrivateKey);
+    console.debug('performBackupRegisterData >> deleteBackupRegisterData success');
+  } catch (e) {
+    console.debug('performBackupRegisterData >> deleteBackupRegisterData failed');
+  }
 
-  await deleteBackupRegisterData(transport, appId, appPrivateKey);
-  if (walletCreated) await backupRegisterData(transport, appId, appPrivateKey);
+  try {
+    const { walletCreated } = await info.getCardInfo(transport);
+    // console.debug(`isCardRecognized: ${isCardRecognized}, walletStatus: ${walletCreated}`);
+    if (walletCreated) {
+      console.debug('performBackupRegisterData >> backupRegisterData try');
+      await backupRegisterData(transport, appId, appPrivateKey);
+      console.debug('performBackupRegisterData >> backupRegisterData success');
+    }
+  } catch (e) {
+    console.debug('performBackupRegisterData >> backupRegisterData failed');
+  }
 };
 
 const performRecoverBackupData = async (transport: Transport): Promise<void> => {

--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -85,9 +85,6 @@ const performBackupRegisterData = async (transport: Transport, appId: string, ap
   const isAppletExist = await safeCheckMainAppletExists(transport);
   if (!isAppletExist) return; // no need to do backup because no main applet.
 
-  // const isCardRecognized = await common.hi(transport, appId);
-  // if (!isCardRecognized) return; // don't do backup becuase card cannot recognize device(appId).
-
   try {
     console.debug('performBackupRegisterData >> deleteBackupRegisterData try');
     await deleteBackupRegisterData(transport, appId, appPrivateKey);
@@ -96,16 +93,12 @@ const performBackupRegisterData = async (transport: Transport, appId: string, ap
     console.debug('performBackupRegisterData >> deleteBackupRegisterData failed');
   }
 
-  try {
-    const { walletCreated } = await info.getCardInfo(transport);
-    // console.debug(`isCardRecognized: ${isCardRecognized}, walletStatus: ${walletCreated}`);
-    if (walletCreated) {
-      console.debug('performBackupRegisterData >> backupRegisterData try');
-      await backupRegisterData(transport, appId, appPrivateKey);
-      console.debug('performBackupRegisterData >> backupRegisterData success');
-    }
-  } catch (e) {
-    console.debug('performBackupRegisterData >> backupRegisterData failed');
+  const { walletCreated } = await info.getCardInfo(transport);
+  const isNeedRecover = await setting.backup.checkBackupStatus(transport);
+  if (walletCreated && isNeedRecover) {
+    console.debug('performBackupRegisterData >> backupRegisterData try');
+    await backupRegisterData(transport, appId, appPrivateKey);
+    console.debug('performBackupRegisterData >> backupRegisterData success');
   }
 };
 

--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -94,8 +94,8 @@ const performBackupRegisterData = async (transport: Transport, appId: string, ap
   }
 
   const { walletCreated } = await info.getCardInfo(transport);
-  const isNeedRecover = await setting.backup.checkBackupStatus(transport);
-  if (walletCreated && isNeedRecover) {
+  const hasBackup = await setting.backup.checkBackupStatus(transport);
+  if (walletCreated && !hasBackup) {
     console.debug('performBackupRegisterData >> backupRegisterData try');
     await backupRegisterData(transport, appId, appPrivateKey);
     console.debug('performBackupRegisterData >> backupRegisterData success');


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR modifies the OTA update process to always attempt to back up registration data, even if the card isn't recognized by the device.  It also adds more robust logging and conditional backup recovery.

**Key Changes**
- Removed the card recognition check (`isCardRecognized`) before backing up registration data.
- Backup register data now occurs if the wallet is created and recovery is needed.
- Added `try-catch` blocks and logging for `deleteBackupRegisterData` and `backupRegisterData` operations.

**Recommendations**
Not deployment ready.  While the change addresses a potential data loss scenario, removing the card recognition check might have unintended consequences.  Consider adding a check for a valid card session or other criteria to ensure the backup process only runs when appropriate.  Additionally, evaluate potential performance impacts of always attempting backup.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>