### PR TITLE
chore(core): bump @coolwallet/core to v2.0.1

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 2.0.1-beta.2
+## 2.0.1
 
+- 🐛 fix: create wallet from seed issue (Go SE 13) (#997)
 - 🐛 fix: firmware update failed if no applet (#1001)
 
 ## 1.2.0-beta.0

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.1-beta.2",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.1-beta.2",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.1-beta.2",
+  "version": "2.0.1",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR bumps the version of `@coolwallet/core` from `2.0.1-beta.2` to `2.0.1`. It includes a fix for creating wallets from seed (Go SE 13).

**Key Changes**
- Updated the version number in `package.json` and `package-lock.json`.
- Added a changelog entry for the bug fix.

**Recommendations**
Ready for deployment. This is a minor version bump with a bug fix, so it's unlikely to introduce breaking changes.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (20%)      |
| Rework      | 4 (80%)      |
| Total Changes | 5           |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>