### PR TITLE
feat(evm): genEthSigFromSESig 支援直接還原 txHash

### DIFF
--- a/packages/coin-evm/package-lock.json
+++ b/packages/coin-evm/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/evm",
-      "version": "2.0.0",
+      "version": "2.0.1-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coolwallet/core": "^2.0.0",
+        "@coolwallet/core": "^2.0.2-beta.1",
         "@metamask/eth-sig-util": "^4.0.0",
         "ajv": "^8.10.0",
         "bn.js": "^5.2.0",
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/@coolwallet/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-lXtRFawJyV/0BtXlWVgm0H/B/8tvVtHUgHCQCwhPDoa5uCbg9gW8R3JKLepq5NnGXd1IPu8xqMt/hzxh2t+6Ww==",
+      "version": "2.0.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@coolwallet/core/-/core-2.0.2-beta.1.tgz",
+      "integrity": "sha512-XIRDsdgrhL67z0y1S+zEKXFRXDWWe0/tIMnf9VKlKBlXId0fT5fz580+Riv9QhSS5KR0LMJk+j3AlzPVWSoc8w==",
       "dependencies": {
         "@types/elliptic": "^6.4.14",
         "@types/lodash": "^4.14.177",

--- a/packages/coin-evm/package.json
+++ b/packages/coin-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.0",
   "description": "Coolwallet EVMOS sdk",
   "main": "lib/index.js",
   "scripts": {
@@ -43,7 +43,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@coolwallet/core": "^2.0.0",
+    "@coolwallet/core": "^2.0.2-beta.1",
     "@metamask/eth-sig-util": "^4.0.0",
     "ajv": "^8.10.0",
     "bn.js": "^5.2.0",


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview:**
This PR updates the `@coolwallet/evm` package to version 2.0.1-beta.0, bumping the `@coolwallet/core` dependency to 2.0.2-beta.1. It introduces a new function `getRecoveryParam` and modifies `genEthSigFromSESig` to support direct transaction hash signing by adding an `alreadyHash` parameter.

**Key Changes:**
- Updated `@coolwallet/core` dependency to 2.0.2-beta.1.
- Added `getRecoveryParam` function to calculate the recovery parameter directly from a data hash, canonical signature, and public key.
- Modified `genEthSigFromSESig` to accept an optional `alreadyHash` boolean.  When true, the function skips hashing the payload, allowing direct use of a transaction hash.

**Recommendations:**
Not deployment ready. While the changes seem reasonable, the impact on existing functionality needs to be thoroughly assessed.  Add comprehensive unit tests to cover the new `getRecoveryParam` function and the modified behavior of `genEthSigFromSESig` with the `alreadyHash` parameter.  Consider adding documentation explaining the usage of the new parameter.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 15 (46.9%)      |
| Churn       | 6 (18.8%)      |
| Rework      | 11 (34.4%)      |
| Total Changes | 32         |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>