### PR TITLE
fix(evm): can't export type from @coolwallet/evm

### DIFF
--- a/packages/coin-evm/package-lock.json
+++ b/packages/coin-evm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.1-beta.1",
+  "version": "2.0.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/evm",
-      "version": "2.0.1-beta.1",
+      "version": "2.0.1-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "^2.0.2-beta.1",

--- a/packages/coin-evm/package.json
+++ b/packages/coin-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.1-beta.1",
+  "version": "2.0.1-beta.2",
   "description": "Coolwallet EVMOS sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/coin-evm/src/index.ts
+++ b/packages/coin-evm/src/index.ts
@@ -246,7 +246,7 @@ class Evm extends COIN.ECDSACoin {
   }
 }
 
-export type * from './transaction/types';
+export * from './transaction/types';
 export * from './utils/signature';
 export * from './utils/rawTransaction';
 export * as CHAIN from './chain';


### PR DESCRIPTION
----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

**Overview**
This PR fixes a type export issue in the `@coolwallet/evm` package, specifically addressing the inability to export types from the `./transaction/types` module.  The fix updates the export statement to correctly export the types.  Additionally, the package version is bumped from `2.0.1-beta.1` to `2.0.1-beta.2`.

**Key Changes**
- Corrected the type export statement in `index.ts` from `export type *` to `export *`.
- Updated the package version in both `package.json` and `package-lock.json` to `2.0.1-beta.2`.

**Recommendations**
Ready for deployment. This is a small, targeted fix that addresses a specific type export issue. The change is low-risk and improves the usability of the library.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 8 (100%) |
| Total Changes | 8 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>