### PR TITLE
chore: bump evm, core and testing-library to stable version

### DIFF
--- a/packages/coin-evm/package-lock.json
+++ b/packages/coin-evm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.1-beta.2",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/evm",
-      "version": "2.0.1-beta.2",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coolwallet/core": "^2.0.2-beta.1",

--- a/packages/coin-evm/package.json
+++ b/packages/coin-evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/evm",
-  "version": "2.0.1-beta.2",
+  "version": "2.0.1",
   "description": "Coolwallet EVMOS sdk",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.2
+- implement signECDSA to improve signing speed
+
 ## 2.0.1
 
 - 🐛 fix: create wallet from seed issue (Go SE 13) (#997)

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.2-beta.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.2-beta.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.2-beta.1",
+  "version": "2.0.2",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/testing-library/package-lock.json
+++ b/packages/testing-library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/testing-library",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/testing-library",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.6.0",

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/testing-library",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0",
   "description": "Testing library for CoolWallet SDKs",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview:** This PR bumps the version of `@coolwallet/evm`, `@coolwallet/core`, and `@coolwallet/testing-library` from beta to formal release versions (2.0.1, 2.0.2, and 2.0.0, respectively). The `core` update includes an implementation of `signECDSA` for improved signing speed.

**Key Changes:**
- Updated version numbers in `package.json` and `package-lock.json` for all three packages.
- Added a changelog entry for `@coolwallet/core` detailing the `signECDSA` implementation.

**Recommendations:**
Ready for deployment. This PR represents a standard version bump with a minor performance improvement.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (25%)      |
| Rework      | 9 (75%)       |
| Total Changes | 12           |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>