### PR TITLE
feat(core): add hooks to BleTransport

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.3
+- feat(core): add hooks to BleTransport
+
 ## 2.0.2
 - implement signECDSA to improve signing speed
 

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.2",
+  "version": "2.0.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.2",
+      "version": "2.0.3-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.2",
+  "version": "2.0.3-beta.1",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -57,8 +57,17 @@ abstract class BleTransport implements Transport {
 
   abstract readDataFromCard(): Promise<number[]>;
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  async onBeforeRequest(command: string, packets: string): Promise<void> {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  async onAfterRequest(result: string): Promise<void> {}
+
   request = async (command: string, packets: string): Promise<string> => {
-    return this.peripheral.sendAPDU(command, packets);
+    await this.onBeforeRequest(command, packets);
+    const result = await this.peripheral.sendAPDU(command, packets);
+    await this.onAfterRequest(result);
+    return result;
   };
 }
 


### PR DESCRIPTION

- **feat: add hooks on BleTransport**
- **chore: bump core to 2.0.2-beta.1**

 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview:**
This PR adds pre and post request hooks to the `BleTransport` class, allowing for actions to be performed before and after a request to the card.  This update is part of version 2.0.3-beta.1.

**Key Changes:**
- Introduced `onBeforeRequest` and `onAfterRequest` hooks in the `BleTransport` class.
- Updated the `request` method to call these hooks before and after sending APDU commands.
- Updated changelog and package version.

**Recommendations:**
Not deployment ready.  The added hooks have default empty implementations.  Provide clear guidance on intended usage and add examples to ensure proper implementation by consumers of the library.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 12 (75%)      |
| Rework      | 4 (25%)       |
| Total Changes | 16           |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>