### PR TITLE
fix(core): update cardInfo.cardanoSeed type from string to boolean @coolwallet/core(2.0.3-beta.3)

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.3-beta.2",
+  "version": "2.0.3-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.3-beta.2",
+      "version": "2.0.3-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.3-beta.2",
+  "version": "2.0.3-beta.3",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/info/index.ts
+++ b/packages/core/src/info/index.ts
@@ -101,7 +101,7 @@ export const getCardInfo = async (
   pairRemainTimes: number;
   accountDigest: string;
   accountDigest20?: string;
-  cardanoSeed?: string;
+  hasCardanoSeed?: boolean;
 }> => {
   try {
     const { outputData, statusCode, msg } = await executeCommand(transport, commands.GET_CARD_INFO, target.SE);
@@ -137,7 +137,7 @@ export const getCardInfo = async (
       pairRemainTimes,
       accountDigest,
     };
-    if (!isNil(bipEd25519IsInit)) set(result, 'cardanoSeed', bipEd25519IsInit === '01');
+    if (!isNil(bipEd25519IsInit)) set(result, 'hasCardanoSeed', bipEd25519IsInit === '01');
     if (!isNil(accountDigest20)) set(result, 'accountDigest20', accountDigest20);
 
     return result;


### PR DESCRIPTION
CardInfo.cardanoSeed has wrong type string, it should be boolean

----

*Checklist:*

- README.md includes:
  - [ ] The details of signing data and transaction data, this includes parameters.
  - [ ] Official docs or white paper.
  - [ ] Website or api can query assets and broadcast transaction.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

 
 **PR Summary by Typo**
------------

**Overview:**
This PR updates the `cardInfo.cardanoSeed` type from string to boolean and renames it to `hasCardanoSeed`. This change improves type safety and clarity by explicitly indicating whether a Cardano seed exists. The version is bumped to 2.0.3-beta.3.

**Key Changes:**
- Changed `cardanoSeed` type from string to boolean in `getCardInfo` response.
- Renamed `cardanoSeed` to `hasCardanoSeed`.
- Updated package version to 2.0.3-beta.3.

**Recommendations:**
Ready for deployment. This is a small, targeted change that improves type safety and code clarity.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 10 |
| Total Changes | 10 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>