### PR TITLE
🐛 [CW-29062] fix(core): 備份 pre-check 容錯改為以安全假設值續行，不再跳過整段備份

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coolwallet/core",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/elliptic": "^6.4.14",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet/core",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Core library for other CoolWallet SDKs.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/core/src/apdu/ota/ota.ts
+++ b/packages/core/src/apdu/ota/ota.ts
@@ -82,8 +82,11 @@ const getProgressNums = (updateMCU: boolean): Array<number> => {
 /**
  * The ignoreXxxError flags are the rescue path for cards stuck in an abnormal state (CW-29062):
  * every command going through the store interface returns 6F00, so the backup step blocks the
- * only way to repair the card. Each flag tolerates exactly one step, and any tolerated failure
- * skips the remaining backup steps and continues the firmware update without backup.
+ * only way to repair the card. Each flag tolerates exactly one step. A tolerated pre-check
+ * failure (checkBackupStatus / getCardInfo) falls back to the assumption that keeps trying to
+ * back up (no backup yet / wallet created) and moves on to the next step, so a feasible backup
+ * is never skipped. Only a tolerated backupRegisterData failure continues the update without
+ * backup — which wipes the wallet on the card at the delete/install step.
  */
 interface PerformBackupRegisterDataOptions {
   transport: Transport;
@@ -114,8 +117,8 @@ const performBackupRegisterData = async ({
     hasBackup = await setting.backup.checkBackupStatus(transport);
   } catch (e) {
     if (!ignoreCheckBackupStatusError) throw e;
-    console.warn(`checkBackupStatus failed, continue firmware update without backup. error: ${e}`);
-    return;
+    console.warn(`checkBackupStatus failed, assume no backup and continue. error: ${e}`);
+    hasBackup = false; // 查不到就當作沒有備份，繼續往下嘗試做備份；就算其實已有備份，重寫的也是同一份資料
   }
   if (hasBackup) return; // no need to do backup because backup already exists.
 
@@ -124,8 +127,8 @@ const performBackupRegisterData = async ({
     ({ walletCreated } = await info.getCardInfo(transport));
   } catch (e) {
     if (!ignoreGetCardInfoError) throw e;
-    console.warn(`getCardInfo failed, continue firmware update without backup. error: ${e}`);
-    return;
+    console.warn(`getCardInfo failed, assume wallet created and continue. error: ${e}`);
+    walletCreated = true; // 查不到就當作有錢包，寧可多做一次備份嘗試，避免漏備份就往下更新
   }
   if (!walletCreated) return; // no need to do backup because wallet not created.
 


### PR DESCRIPTION
## Key Changes

pre-check 容錯改為以「會繼續嘗試備份」的安全假設值往下走：

| 容錯點 | 原行為 | 新行為 |
|---|---|---|
| `checkBackupStatus` 失敗 | `return`（跳過備份） | `hasBackup = false`，繼續往下嘗試備份 |
| `getCardInfo` 失敗 | `return`（跳過備份） | `walletCreated = true`，寧可多做一次備份嘗試 |
| `backupRegisterData` 失敗 | warn 後續行 | 不變 —— 唯一「無備份仍續行更新」的出口 |

改完後「無備份即更新（錢包被清）」只可能由 `ignoreBackupRegisterDataError` 明確授權。就算 `checkBackupStatus` 誤判（其實已有備份），重寫一次備份的內容也是當下同一份資料，無害。

- flag 全關時行為不變（catch 直接 rethrow）
- 同步改寫 `PerformBackupRegisterDataOptions` 的 JSDoc
- Bump `@coolwallet/core` 至 2.0.12

## Verification

- `tsc --noEmit` 通過
- 已於實卡驗證：模擬 `checkBackupStatus` 失敗 + flag 開啟時，流程如預期續行至 `getCardInfo` 而非跳過備份


🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the core backup pre-check error handling during firmware updates to use safe fallback assumptions instead of skipping the entire backup process when pre-check commands fail.

#### Key Changes
- Bumped package version to `2.0.12` in `package.json` and `package-lock.json`.
- Updated `performBackupRegisterData` in `ota.ts` to fallback to `hasBackup = false` on `checkBackupStatus` failure rather than aborting.
- Updated `performBackupRegisterData` to fallback to `walletCreated = true` on `getCardInfo` failure to ensure backup attempts proceed safely.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (25.0%)     |
| Rework      | 9 (75.0%)     |
| Total Changes | 12          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>