### PR TITLE
✨ [CW-29100] feat(evm): support token spec argument in tools/token.ts

### DIFF
--- a/packages/coin-evm/tools/token.ts
+++ b/packages/coin-evm/tools/token.ts
@@ -11,6 +11,22 @@ const buildTokenHex = (token: BuildTokenHexInput) => {
   return `${unitHex}${symbolLengthHex}${symbolHex}${address}`;
 };
 
+// Batch mode: `npm run list:token -- BSC:TWT:18:0x4B0F...` prints only the requested tokens, so a
+// token that isn't in this package's chain modules yet (a brand new one being signed for the first
+// time) can still get its hex from this script instead of a second copy of buildTokenHex elsewhere.
+// With no arguments the hardcoded list below runs unchanged.
+const specs = process.argv.slice(2);
+if (specs.length > 0) {
+  for (const spec of specs) {
+    const [chain, symbol, unit, contractAddress] = spec.split(':');
+    if (!chain || !symbol || !unit || !contractAddress) {
+      throw new Error(`Expected a "<chain>:<symbol>:<unit>:<contractAddress>" spec, got "${spec}"`);
+    }
+    console.log(`${chain} ${symbol}: `, buildTokenHex({ symbol, unit, contractAddress }));
+  }
+  process.exit(0);
+}
+
 console.log('ARB USD₮0: ', buildTokenHex(ARBITRUM.tokens['USDT0']));
 console.log('ARB USDC.e: ', buildTokenHex(ARBITRUM.tokens['USDC.e']));
 console.log('ARB DAI: ', buildTokenHex(ARBITRUM.tokens.DAI));


### PR DESCRIPTION
> ⚠️ Code review gate skipped (`--skip-review`); reviewer 請自行留意 diff 品質。

## Overview

`packages/coin-evm/tools/token.ts` could only print the Signing Hex for tokens it looks up in the chain modules, which means a token that is not in the registry yet cannot get a hex from it at all. This PR lets the script build the hex for a token spec passed on the command line, so the encoding logic stays in this one place instead of being copied into whatever tool needs a hex for a new token.

## Key Changes

- Added a batch mode to `tools/token.ts`: given one or more `<chain>:<symbol>:<unit>:<contractAddress>` arguments the script prints only the requested tokens and exits, while running it with no arguments keeps the existing hardcoded list exactly as it was, so the manual signing flow is untouched.
- Routed batch mode through the existing `buildTokenHex` rather than adding a second encoder, so a hex produced this way is identical to what the current manual flow produces.
- Rejected malformed specs with an explicit error instead of letting a missing field silently produce a short or misaligned hex, since the output of this script goes straight onto a signing card.

## Verification

- `npx tsc --noEmit -p tsconfig.json` passes for `coin-evm`.
- Ran the script with no arguments on this branch and on `master` and diffed the output: byte-identical.
- Ran `BSC:USDT:18:0x55d398326f99059ff775485246999027b3197955` and confirmed the resulting hex `12045553445400000055d398326f99059ff775485246999027b3197955` matches the prefix of the USDT signature already stored in `src/chain/bsc/token.ts`, i.e. it reproduces what was signed manually before.

## Related

- Task: https://app.clickup.com/t/CW-29100
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates `packages/coin-evm/tools/token.ts` to support passing token specifications via CLI arguments. This allows generating token hex values dynamically for unlisted tokens without modifying the script's hardcoded tokens list.

#### Key Changes
- Added support for CLI arguments matching the format `<chain>:<symbol>:<unit>:<contractAddress>`.
- Updated execution flow to parse CLI arguments, compute token hexes via `buildTokenHex`, and exit early when parameters are supplied.
- Added input validation to ensure all required fields in the CLI token specification string are present.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 16 (100.0%)   |
| Total Changes | 16          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>