### PR TITLE
🐛 [CW-29159] fix(sol): 修正 isBase58Format 誤判與測試浮點數精度問題

### DIFF
--- a/packages/coin-sol/package-lock.json
+++ b/packages/coin-sol/package-lock.json
@@ -28,7 +28,8 @@
         "@types/bs58": "^4.0.1",
         "@types/node": "^18.19.76",
         "bip39": "^3.0.4",
-        "regenerator-runtime": "^0.14.1"
+        "regenerator-runtime": "^0.14.1",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5101,11 +5102,10 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/coin-sol/package.json
+++ b/packages/coin-sol/package.json
@@ -46,7 +46,8 @@
     "@types/bs58": "^4.0.1",
     "@types/node": "^18.19.76",
     "bip39": "^3.0.4",
-    "regenerator-runtime": "^0.14.1"
+    "regenerator-runtime": "^0.14.1",
+    "typescript": "^5.9.3"
   },
   "repository": {
     "type": "git",

--- a/packages/coin-sol/src/utils/stringUtil.ts
+++ b/packages/coin-sol/src/utils/stringUtil.ts
@@ -7,6 +7,7 @@ const HEX_REGEX = /[0-9A-Fa-f]{6}/g;
 
 export const isBase58Format = (value?: string): boolean => {
   if (!value) return false;
+  if (value.length !== 43 && value.length !== 44) return false;
   return /^[A-HJ-NP-Za-km-z1-9]*$/.test(value);
 };
 

--- a/packages/coin-sol/src/utils/stringUtil.ts
+++ b/packages/coin-sol/src/utils/stringUtil.ts
@@ -7,8 +7,8 @@ const HEX_REGEX = /[0-9A-Fa-f]{6}/g;
 
 export const isBase58Format = (value?: string): boolean => {
   if (!value) return false;
-  if (value.length !== 43 && value.length !== 44) return false;
-  return /^[A-HJ-NP-Za-km-z1-9]*$/.test(value);
+  if (!/^[A-HJ-NP-Za-km-z1-9]*$/.test(value)) return false;
+  return base58.decode(value).length === 32;
 };
 
 function isHexFormat(value: string): boolean {

--- a/packages/coin-sol/tests/index.spec.ts
+++ b/packages/coin-sol/tests/index.spec.ts
@@ -106,7 +106,7 @@ describe('Test Solana SDK', () => {
     const expectedWallet = Keypair.fromSeed(node.privateKey);
     const toPubkey = getRandWallet();
     const recentBlockhash = getRandWallet();
-    const lamports = ((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL;
+    const lamports = Math.round(((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL);
 
     const signTxData = {
       transport,
@@ -489,7 +489,7 @@ describe('Test Solana SDK', () => {
     const SEED = 'stake:0';
     const STAKE_ACCOUNT = await sol.createWithSeed(FROM_PUBKEY.toString(), SEED, StakeProgram.programId.toString());
     const VALIDATOR = new PublicKey(getRandWallet());
-    const lamports = ((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL;
+    const lamports = Math.round(((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL);
     const signTxData = {
       transport,
       appPrivateKey: props.appPrivateKey,
@@ -559,7 +559,7 @@ describe('Test Solana SDK', () => {
     const FROM_PUBKEY = expectedWallet.publicKey;
     const toPubkey = getRandWallet();
     const recentBlockhash = getRandWallet();
-    const lamports = ((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL;
+    const lamports = Math.round(((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL);
 
     const signTxData = {
       transport,
@@ -614,7 +614,7 @@ describe('Test Solana SDK', () => {
     const addressIndex = 0;
     const node = wallet.derivePath(bip32Path(addressIndex));
     const expectedWallet = Keypair.fromSeed(node.privateKey);
-    const lamports = ((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL;
+    const lamports = Math.round(((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL);
     const recentBlockhash = getRandWallet();
     const stakePubkey = getRandWallet();
     const withdrawToPubKey = getRandWallet();
@@ -673,7 +673,7 @@ describe('Test Solana SDK', () => {
     const addressIndex = 0;
     const node = wallet.derivePath(bip32Path(addressIndex));
     const expectedWallet = Keypair.fromSeed(node.privateKey);
-    const lamports = ((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL;
+    const lamports = Math.round(((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL);
     const recentBlockhash = getRandWallet();
     const stakePubkey = getRandWallet();
     const withdrawToPubKey = expectedWallet.publicKey;

--- a/packages/coin-sol/tests/stringUtil.test.ts
+++ b/packages/coin-sol/tests/stringUtil.test.ts
@@ -1,0 +1,26 @@
+import { isBase58Format } from '../src/utils/stringUtil';
+
+describe('isBase58Format', () => {
+  it('rejects a 64-char hex pubkey that happens to contain no "0" (CW-29159)', () => {
+    const hexPubkeyWithoutZero = '823f917cc28dbcccb9877a6e915bdf87bb86a55f6684a782555e2833d6534581';
+    expect(hexPubkeyWithoutZero).toHaveLength(64);
+    expect(isBase58Format(hexPubkeyWithoutZero)).toBe(false);
+  });
+
+  it('accepts a valid 44-char base58 pubkey', () => {
+    expect(isBase58Format('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')).toBe(true);
+  });
+
+  it('accepts a valid 43-char base58 pubkey', () => {
+    expect(isBase58Format('So11111111111111111111111111111111111111112')).toBe(true);
+  });
+
+  it('rejects a base58-charset string that is shorter than a 32-byte pubkey', () => {
+    expect(isBase58Format('11111111111111111111111111111111')).toBe(false);
+  });
+
+  it('rejects empty or undefined input', () => {
+    expect(isBase58Format('')).toBe(false);
+    expect(isBase58Format(undefined)).toBe(false);
+  });
+});

--- a/packages/coin-sol/tests/stringUtil.test.ts
+++ b/packages/coin-sol/tests/stringUtil.test.ts
@@ -1,3 +1,4 @@
+import base58 from 'bs58';
 import { isBase58Format } from '../src/utils/stringUtil';
 
 describe('isBase58Format', () => {
@@ -15,8 +16,16 @@ describe('isBase58Format', () => {
     expect(isBase58Format('So11111111111111111111111111111111111111112')).toBe(true);
   });
 
-  it('rejects a base58-charset string that is shorter than a 32-byte pubkey', () => {
-    expect(isBase58Format('11111111111111111111111111111111')).toBe(false);
+  it('accepts the System Program ID, whose leading zero bytes shrink it to 32 chars', () => {
+    const systemProgramId = '1'.repeat(32);
+    expect(base58.decode(systemProgramId)).toHaveLength(32);
+    expect(isBase58Format(systemProgramId)).toBe(true);
+  });
+
+  it('rejects a base58-charset string that decodes to more than 32 bytes', () => {
+    const tooLong = '1'.repeat(34);
+    expect(base58.decode(tooLong)).toHaveLength(34);
+    expect(isBase58Format(tooLong)).toBe(false);
   });
 
   it('rejects empty or undefined input', () => {

--- a/packages/coin-sol/tests/tsconfig.json
+++ b/packages/coin-sol/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "noEmit": true,
+    "declaration": false,
+    "rootDir": "..",
+    "skipLibCheck": true
+  },
+  "include": ["**/*"]
+}

--- a/packages/coin-sol/tsconfig.json
+++ b/packages/coin-sol/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "outDir": "lib",                          /* Redirect output structure to the directory. */
+    "rootDir": "src",                         /* Specify the root directory of input files. */
     
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
## Overview

這支 PR 修復 CW-29159 記錄的兩個 coin-sol 潛伏 bug：`isBase58Format` 會把特定 64 字元 hex 公鑰誤判成合法 base58，導致 SPL Token 轉帳交易的帳戶順序偶發跟 `@solana/web3.js` 對不上；以及測試 fixture 因浮點數精度問題導致 lamports 斷言偶發失敗。另外一併修掉編輯器裡 `tests/` 目錄型別檢查失效的問題。

## Key Changes

- 修正 `isBase58Format`：64 字元 hex 公鑰若剛好不含 `'0'` 字元，字元集會落在 base58 字元集內被誤判成合法 base58，導致 `toBase58()`/`formHex()` 在 `compileMessage()` 排序 tie-break 時用錯值，使簽出的帳戶順序與 `@solana/web3.js` 不一致（機率約 0.4~1.6%）。最終改成直接 `base58.decode(value).length === 32` 驗證實際位元組長度，而不是用字串長度範圍近似猜測——過程中先用「長度必須是 43 或 44」這個近似值，經 code review 抓出會誤判 System Program ID 這類開頭有 0x00 byte、編碼後較短的合法地址，故改為直接解碼驗證，並補上這個邊界案例的 regression test。
- 修正 `tests/index.spec.ts` 5 處 lamports 測試 fixture：`((getRandInt(10000000) + 1) / 10000000.0) * LAMPORTS_PER_SOL` 偶爾算出非整數，簽入交易時 `bn.js` 靜默捨去小數，但斷言用的是未捨去的原始 float，兩邊對不上導致偶發失敗（實測機率約 3.4%）；改用 `Math.round` 讓簽章與斷言共用同一個整數值。
- 新增 `packages/coin-sol/tests/tsconfig.json` 並在 `packages/coin-sol/tsconfig.json` 補上 `rootDir`：原本 `tsconfig.json` 只 include `src/**/*`，`tests/` 底下的檔案在編輯器裡找不到 jest 全域型別（`describe`/`it`），連帶為 `coin-sol` 加裝本地 `typescript@^5.9.3`（原本繼承 root 4.7.4 無法解析 `@solana/web3.js` 間接依賴 `@solana/codecs-data-structures` 的新版語法）。

## Verification

- `packages/coin-sol/tests/stringUtil.test.ts`（含 System Program ID 邊界案例）與 `packages/coin-sol/src/utils/__tests__/scriptUtil.test.ts` 共 20 個測試全過。
- `tsc -p packages/coin-sol/tests/tsconfig.json --noEmit` 與 `tsc -p packages/coin-sol/tsconfig.json --noEmit`（`build:types` 實際用的 config）皆 0 error，且 `rootDir` 改動前後編譯輸出以 `diff` 比對完全一致。
- Ran `swiss-knife:code-review`（scope: `git diff origin/chore/CW-29104-bump-token-package-versions...HEAD`）— 抓到一個 blocking finding（`isBase58Format` 長度範圍檢查誤判 System Program ID 類地址），已修復並重新驗證，目前無 blocking finding。
- `packages/coin-sol/tests/index.spec.ts` 本身在本機環境因為 monorepo 內多個 package 的 `node_modules/@coolwallet/core` 版本不一致（既有環境問題，跟本次改動無關）沒有實際執行，`lamports` 修正屬於單純算術等價替換（`Math.round` 讓簽章與斷言用同值），CI 應可正常跑過票上記錄的 476 個 `coin-sol` 測試。

## Related

- Task: https://app.clickup.com/t/86eyrxj4c
 
 **PR Summary by Typo**
------------

#### Overview
This PR fixes an issue where `isBase58Format` allowed non-standard string formats by validating that the decoded Base58 payload exactly matches a 32-byte public key length. It also addresses floating-point precision issues in test transaction calculations by rounding lamport values.

#### Key Changes
- Updated `isBase58Format` in `stringUtil.ts` to enforce a decoded byte length of 32.
- Wrapped test `lamports` calculations with `Math.round` to avoid floating-point precision errors during test runs.
- Added dedicated unit tests for `isBase58Format` covering valid Solana public key formats, invalid lengths, and edge cases.
- Updated package dependencies and TypeScript compiler settings.

#### Work Breakdown

| Category | Lines Changed |
| --- | --- |
| New Work | 50 (80.6%) |
| Churn | 1 (1.6%) |
| Refactor | 11 (17.7%) |
| Total Changes | 62 | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>